### PR TITLE
[binutils] Move back to bfd as the default linker

### DIFF
--- a/packages/binutils/ChangeLog
+++ b/packages/binutils/ChangeLog
@@ -1,5 +1,10 @@
 2019-08-04  Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
 
+	* 2.32-5 :
+	Use bfd as default linker
+
+2019-08-04  Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
+
 	* 2.32-4 :
 	Upload source package
 

--- a/packages/binutils/PKGBUILD
+++ b/packages/binutils/PKGBUILD
@@ -5,7 +5,7 @@
 pkgname='binutils'
 rationale='This is part of the core toolchain'
 pkgver=2.32
-pkgrel=4
+pkgrel=5
 pkgdesc='A collection of binary tools, including a linker and an assembler'
 arch=('x86_64')
 url='http://www.gnu.org/software/binutils/'
@@ -36,7 +36,7 @@ build() {
       --build="$CHOST" \
       --host="$CHOST" \
       --target="$CHOST" \
-      --enable-gold=default \
+      --enable-64-bit-bfd \
       --enable-plugins \
       --enable-shared \
       --disable-werror \


### PR DESCRIPTION
There still seem to be issues with some packages using gold with
musl and bfd is satisfactory for now.