### PR TITLE
Add a convenience script to mere/dev image

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,11 +1,13 @@
 FROM mere/base
 
 COPY packages/pacman/pacman-dev.conf /etc/pacman.conf
+COPY scripts/build-in-docker.sh /local/bin
 
 RUN install -d /mere/pkgs && \
     touch /mere/pkgs/buildlocal.db && \
     pacman -Syu --noconfirm && \
     pacman -Sy --noconfirm build-essential && \
+    chmod +x /local/bin/build-in-docker.sh && \
     find /var/cache/pacman -not -type d -delete
 
 WORKDIR /src

--- a/scripts/build-in-docker.sh
+++ b/scripts/build-in-docker.sh
@@ -1,0 +1,12 @@
+#!/bin/sh -e
+
+cd /src
+
+pacman -Syu --noconfirm
+makepkg -Ls --noconfirm
+
+find /tmp/staging -name "*.pkg*" | while read -r file ; do
+    cp -a "$file" "/mere/pkgs/";
+    pacman -Dk >/dev/null;
+    repo-add -R /mere/pkgs/buildlocal.db.tar.gz "/mere/pkgs/${file##*/}";
+done


### PR DESCRIPTION
This will make it easier to execute a build inside docker in a
consistent way.