### PR TITLE
Adjust building methods to consistently use Docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 version: 2.1
 executors:
-  build-essential:
+  build-env:
     docker:
-      - image: mere/build-essential
+      - image: mere/dev
 jobs:
   lint:
-    executor: build-essential
+    executor: build-env
     steps:
       - run:
           name: Install tools and upgrade
@@ -18,7 +18,7 @@ jobs:
             find packages -name PKGTEST -exec shellcheck '{}' +
             find scripts -type f -exec shellcheck '{}' +
   build:
-    executor: build-essential
+    executor: build-env
     steps:
       - run:
           name: Install tools

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,96 +1,26 @@
 #!/bin/sh -e
-PATH="/mere/bin:$PATH"
-shome="/tmp/wd"
-clog=/var/log/merebuild.log
-auto=0
-
-msg() {
-    printf '%s\n' "$1"
-}
-
-info() {
-    msg "INF: $1"
-}
-
-error() {
-    msg "ERR: $1"
-    exit 1
-}
 
 usage() {
     printf '
-Usage: %s <pkgdir> [options]
+Usage: %s <pkgdir>
 
   <pkgdir>   Identifies a directory containing, at minimum, a PKGBUILD file.
              The directory may also contain a ChangeLog file and additional
              source files required for the build.
-
-  -a,--auto  Run a container in the foreground, but non-interactively.
-             Signals are ignored.
-
 ' "$0"
 }
 
 if [ -z "$1" ] || [ ! -d "$1" ] ; then
     usage
-    error "Missing or invalid directory. pkgdir argument: ${pkgdir}"
+    printf 'Missing or invalid directory. pkgdir argument: %s\n' "${pkgdir}"
 else
     pkgdir=$(realpath "$1")
-    name="merebuild-${pkgdir##*/}"
     shift
 fi
 
-if options=$(getopt -o a -l auto -- "$@" 2>&1); then
-    eval set -- "$options"
-    while true
-    do
-        case "$1" in
-            -a|--auto) auto=1; shift 2;;
-            --)        shift 1; break;;
-            *)         break;;
-        esac
-    done
-else
-    usage
-    error "$(printf "%s" "$options" | head -n1 | sed 's@getopt: @@')"
-fi
-
-# Make sure required mountpoints are present
-mountpoint -q /sys/fs/cgroup || mount -t tmpfs cgroupfs /sys/fs/cgroup
-awk '!/^#/ { if ($4 == 1) print $1 }' /proc/cgroups | \
-    while IFS= read -r sys
-do
-    sys_path="/sys/fs/cgroup/${sys}"
-    mkdir -p "$sys_path"
-    mountpoint -q "$sys_path" ||
-        mount -n -t cgroup -o "$sys" cgroup "$sys_path" ||
-        rmdir "$sys_path" ||
-        true
-done
-
-# Start fresh
-info "Stopping and destroying any existing container named $name"
-lxc-stop -k -n "$name" >/dev/null 2>&1 || true
-lxc-destroy -n "$name" >/dev/null 2>&1 || true
-
-# Create the container
-info "Creating a fresh merebuild container named $name"
-mere_package="$pkgdir" lxc-create -n "$name" -t merebuild >>"$clog" 2>&1 ||
-    error "Failed to create container. Examine ${clog} for details."
-
-# Execute the container
-if [ $auto -eq 1 ] ; then
-    [ -n "$mere_no_deps" ] && mere_no_deps='-d'
-    info "Running the container"
-    lxc-start -n "$name" -F -- \
-        /bin/env -i TERM="$TERM" HOME="$shome" \
-        /bin/sh -lc "cd ${shome} && makepkg -Ls --noconfirm ${mere_no_deps}"
-else
-    info "Entering the container"
-    lxc-start -n "$name" -F -- \
-    /bin/env -i TERM="$TERM" HOME="$shome" \
-    /bin/sh -c "cd ${shome} &&
-        printf '\\nReady.\\nTo make the package, run: makepkg -Ls\\n\\n' &&
-        exec /bin/bash -l"
-
-fi
+docker run -it --rm \
+    -v "${pkgdir}":/src \
+    -v /mere/logs:/mere/logs \
+    -v /mere/pkgs:/mere/pkgs \
+    -v /mere/sources:/mere/sources \
+    mere/dev:latest /local/bin/build-in-docker.sh

--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2154,SC1090
 . "$CIRCLE_WORKING_DIRECTORY"/.env
 if [ -n "$pkg" ] ; then
-    pacman -Sy
+    pacman -Syu --noconfirm
     . "$pkg"/PKGBUILD
     proposed="${pkgver}-${pkgrel}"
     current="$(pacman -Sl | grep "${pkgname} " | cut -d' ' -f3)"

--- a/scripts/ci-upload.sh
+++ b/scripts/ci-upload.sh
@@ -17,7 +17,7 @@ sed -i '/bsdtar -xf .*dbfile/s@-C@--no-fflags -C@' /bin/repo-add
 find /tmp/staging -name "*.src.tar.xz" -exec mv '{}' pkgs/testing/ \;
 find /tmp/staging -name "*.pkg*" | while read -r file ; do
     mv "$file" pkgs/testing
-    repo-add pkgs/testing/main.db.tar.gz "pkgs/testing/${file##*/}"
+    repo-add -R pkgs/testing/main.db.tar.gz "pkgs/testing/${file##*/}"
 done
 
 aws s3 sync pkgs s3://pkgs.merelinux.org


### PR DESCRIPTION
* Use mere/dev in circle-ci pipeline config
* Use mere/dev and docker for local builds