### PR TITLE
[linux-headers] Use a separate PKGBUILD

### DIFF
--- a/packages/linux-headers/ChangeLog
+++ b/packages/linux-headers/ChangeLog
@@ -1,0 +1,4 @@
+2021-02-20  Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
+
+	* 5.10.17-1 :
+	Initial version

--- a/packages/linux-headers/PKGBUILD
+++ b/packages/linux-headers/PKGBUILD
@@ -1,0 +1,40 @@
+#!/bin/bash
+# shellcheck disable=SC2034,SC2154,SC2068
+# Maintainer: Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
+
+rationale='This is part of the core toolchain'
+pkgname=linux-headers
+pkgver=5.10.17
+pkgrel=1
+pkgdesc='System headers'
+arch=(x86_64)
+url='http://www.kernel.org'
+license=(GPL2)
+groups=(base)
+depends=()
+makedepends=()
+options=()
+changelog=ChangeLog
+source=(
+    "https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-$pkgver.tar.xz"
+)
+
+sha256sums=(
+    e84e623ce8bb2446ec026b62eafa3b18480aa6fb6ae9c86cd8f18651324d4814
+)
+
+build() {
+    cd "${srcdir}/linux-${pkgver}" || return 1
+    make mrproper
+    sed -i \
+        -e "/rsync/s@rsync@find usr/include -not -type d -name '*.h' | cpio -dump --quiet \$\(INSTALL_HDR_PATH\); true@" \
+        -e '/^CC/s@gcc@cc@g' \
+        -e '/^HOSTCC/s@gcc@cc@g' Makefile
+    make INSTALL_HDR_PATH=dest HOSTCFLAGS="-D_GNU_SOURCE" headers_install
+}
+
+package() {
+    cd "${srcdir}/linux-${pkgver}/dest/usr" || return 1
+    set -o pipefail
+    find include -not -type d -name "*.h" | cpio -dump "${pkgdir}"
+}


### PR DESCRIPTION
The linux-headers as part of the system toolchain can be separate from
the running kernel. Track them separately for easier packaging and
build requirements.