### PR TITLE
[dropbear] Upgrade to 2020.81

### DIFF
--- a/packages/dropbear/ChangeLog
+++ b/packages/dropbear/ChangeLog
@@ -1,3 +1,8 @@
+2021-02-22  Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
+
+	* 2020.81-1 :
+	Upgrade to 2020.81
+
 2019-08-08  Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
 
 	* 2019.78-1 :

--- a/packages/dropbear/PKGBUILD
+++ b/packages/dropbear/PKGBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
 
 pkgname=dropbear
-pkgver=2019.78
+pkgver=2020.81
 pkgrel=1
 pkgdesc='A relatively small SSH server and client.'
 arch=(x86_64)
@@ -23,7 +23,7 @@ source=(
 )
 
 sha256sums=(
-    525965971272270995364a0eb01f35180d793182e63dd0b0c3eb0292291644a4
+    48235d10b37775dbda59341ac0c4b239b82ad6318c31568b985730c788aac53b
     743b0d8c6e7a60f07910daa913bfb5717e98b47654ac7cffaafff15a1c3a7566
     992a38e175c6dd8dea0c0496dbe175749f0f18eee6d861d913cd8f5bfe19a37a
     678981da5f219b6d335e132073ce5516e51470f80d17f33b282af259d846c5b0
@@ -48,7 +48,7 @@ package() {
     make DESTDIR="$pkgdir" \
       PROGRAMS="dropbear dbclient dropbearkey dropbearconvert scp" \
       install
-    ln -s dbclient "${pkgdir}/bin/ssh"
+    mv "${pkgdir}/bin/scp" "${pkgdir}/bin/dropbear-scp"
     install -d -m 0755 "${pkgdir}/etc/dropbear"
     install -d "${pkgdir}/etc/s6/services/available/dropbear/log"
     install -m 0754 "${srcdir}/dropbear-service" \


### PR DESCRIPTION
Also remove 'ssh' and 'scp' symlinks, since these will conflict with
openssh-client, which is needed for some specific features in the
pipelines, and no doubt, elsewhere. Should find a way to support
alternatives.