### PR TITLE
[llvm] Add llvm-strip and build for native only

### DIFF
--- a/packages/llvm/ChangeLog
+++ b/packages/llvm/ChangeLog
@@ -1,3 +1,13 @@
+2021-03-18  Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
+
+	* 11.1.0-4 :
+	Build only the native target
+
+2021-03-18  Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
+
+	* 11.1.0-3 :
+	Add llvm-strip
+
 2021-03-13  Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
 
 	* 11.1.0-2 :

--- a/packages/llvm/PKGBUILD
+++ b/packages/llvm/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=llvm
 pkgver=11.1.0
-pkgrel=2
+pkgrel=4
 pkgdesc='A collection of modular and reusable compiler and toolchain technologies.'
 arch=('x86_64')
 url='htps://llvm.org'
@@ -40,12 +40,11 @@ build() {
     cd build || return 1
     cmake -G Ninja -Wno-dev \
         -DCMAKE_INSTALL_PREFIX='' \
-        -DCLANG_BUILD_EXAMPLES=OFF \
         -DCMAKE_BUILD_TYPE=Release \
+        -DCLANG_BUILD_EXAMPLES=OFF \
         -DCLANG_DEFAULT_CXX_STDLIB='libc++' \
         -DCLANG_DEFAULT_RTLIB='compiler-rt' \
         -DCLANG_ENABLE_BOOTSTRAP=ON \
-        -DCLANG_VENDOR='Mere' \
         -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
         -DCOMPILER_RT_BUILD_XRAY=OFF \
         -DCOMPILER_RT_USE_LIBCXX=ON \
@@ -55,17 +54,15 @@ build() {
         -DLIBCXXABI_USE_COMPILER_RT=ON \
         -DLIBCXXABI_USE_LLVM_UNWINDER=ON \
         -DLLVM_DEFAULT_TARGET_TRIPLE='x86_64-unknown-linux-musl' \
-        -DLLVM_DISTRIBUTION_COMPONENTS='clang;clang-resource-headers;lld;LTO;compiler-rt;addr2line;ar;objcopy;objdump;nm;ranlib;size;strings;strip;unwind;cxx;cxxabi' \
-        -DLLVM_ENABLE_EH=ON \
+        -DLLVM_DISTRIBUTION_COMPONENTS='clang;clang-resource-headers;lld;LTO;compiler-rt;addr2line;llvm-strip;ar;objcopy;objdump;nm;ranlib;size;strings;strip;unwind;cxx;cxxabi' \
         -DLLVM_ENABLE_LIBCXX=ON \
         -DLLVM_ENABLE_PROJECTS='lld;clang;compiler-rt;libunwind;libcxx;libcxxabi' \
-        -DLLVM_ENABLE_RTTI=ON \
         -DLLVM_ENABLE_TERMINFO=OFF \
         -DLLVM_HOST_TRIPLE='x86_64-unknown-linux-musl' \
         -DLLVM_INSTALL_BINUTILS_SYMLINKS=ON \
         -DLLVM_INSTALL_TOOLCHAIN_ONLY=ON \
+        -DLLVM_TARGETS_TO_BUILD=Native \
         -DLLVM_PARALLEL_COMPILE_JOBS="$(nproc)" \
-        -DPACKAGE_VENDOR='Mere' \
         ../llvm
     cmake --build .
 }


### PR DESCRIPTION
* The linux kernel build system expects llvm-strip
* Building for the native target only reduces the package size by around
  half its current size