### PR TITLE
[acl] Remove from groups for now

### DIFF
--- a/packages/acl/ChangeLog
+++ b/packages/acl/ChangeLog
@@ -1,3 +1,8 @@
+2021-04-08  Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
+
+	* 2.2.53-8 :
+	Remove from any groups for now
+
 2021-02-21  Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
 
 	* 2.2.53-7 :

--- a/packages/acl/PKGBUILD
+++ b/packages/acl/PKGBUILD
@@ -9,12 +9,12 @@ pkgname=(
     libacl-dev
 )
 pkgver=2.2.53
-pkgrel=7
+pkgrel=8
 pkgdesc='A library for manipulating POSIX access control lists'
 arch=(x86_64)
 url='http://savannah.nongnu.org/projects/acl'
 license=(GPL)
-groups=(base)
+groups=()
 depends=()
 makedepends=(gettext libattr-dev)
 options=()


### PR DESCRIPTION
In the process of defining 'core' and 'core-dev' groups. Will evaluate
additional groups in the future