### PR TITLE
Update toolchain and base-layout to use /usr

### DIFF
--- a/packages/base-layout/PKGBUILD
+++ b/packages/base-layout/PKGBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
 
 pkgname=base-layout
-pkgver=1.9
+pkgver=2.0
 pkgrel=1
 pkgdesc='The base directory structure and a few core files for the system.'
 arch=('x86_64')
@@ -25,7 +25,7 @@ source=(
 sha256sums=(
     e1d32f445c3a6da06f9787ec7b8d59bb789dde4ad95e12b62ece5b68f307777e
     79aa3fb64f0b0d18ed4c53680d1fc991f7782dda9dcafc6bb592648056e21057
-    182754543753adbc9bcd5c03e55ca49603be6ed181770676920d7bb9277f7e77
+    da5cf257af94cdae7efdbf67aba27f937bcc785ad01e5bde5d116bf2904079c9
     1dcc1e00d7189fa105c726b253aab416b3c0d47e432ac9958db54c7faacb9ac7
     b4d36eb75767bebb41c5fa7a35599952e1883b3d3f6332496e1561eeb4067018
     297b784a25fc59641589c6ef05dc26680e2805e9cab37a4ea3699aa072a25c2e
@@ -47,23 +47,16 @@ package() {
     install -d "${pkgdir}/etc/default"
     ln -s /proc/mounts "${pkgdir}/etc/mtab"
     install -d "${pkgdir}/home"
-    install -d "${pkgdir}/include"
     install -d "${pkgdir}/lib/modules"
-    install -d "${pkgdir}/local/"{bin,include,lib,sbin,share}
+    install -d "${pkgdir}/mnt"
     install -d -m 0555 "${pkgdir}/proc"
     install -d -m 0750 "${pkgdir}/root"
     install -d -m 1777 "${pkgdir}/run"
     install -d "${pkgdir}/sbin"
     install -d -m 0555 "${pkgdir}/sys"
     install -d -m 1777 "${pkgdir}/tmp"
-    install -d "${pkgdir}/share"
-    install -d "${pkgdir}/usr"
-    ln -s ../bin     "${pkgdir}/usr/bin"
-    ln -s ../include "${pkgdir}/usr/include"
-    ln -s ../local   "${pkgdir}/usr/local"
-    ln -s ../sbin    "${pkgdir}/usr/sbin"
-    ln -s ../share   "${pkgdir}/usr/share"
-    chmod 0555 "${pkgdir}/usr"
+    install -d "${pkgdir}/srv"
+    install -d "${pkgdir}/usr/"{bin,include,local/bin,local/sbin,sbin,share/man}
     install -d "${pkgdir}/var/"{cache,lock,lib,log,mail,spool}
     ln -s /run "${pkgdir}/var/run"
     install -d -m 1777 "${pkgdir}/var/tmp"

--- a/packages/base-layout/profile
+++ b/packages/base-layout/profile
@@ -5,12 +5,12 @@
 hn=$(hostname -s)
 id=$(id -u)
 P='$'
-PATH='/local/bin:/bin'
+PATH='/usr/local/bin:/bin:/usr/bin'
 
 # Special cases for root
 if [ "$id" = '0' ] ; then
     P='#'
-    PATH='/local/bin:/local/sbin:/bin:/sbin'
+    PATH='/usr/local/bin:/usr/local/sbin:/bin:/sbin'
 fi
 
 set_ps1() {

--- a/packages/linux-headers/ChangeLog
+++ b/packages/linux-headers/ChangeLog
@@ -1,3 +1,9 @@
+2021-04-09  Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
+
+	* 5.10.17-2 :
+	Set install prefix to /usr
+	Add to new group core-dev
+
 2021-02-20  Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
 
 	* 5.10.17-1 :

--- a/packages/linux-headers/PKGBUILD
+++ b/packages/linux-headers/PKGBUILD
@@ -5,12 +5,12 @@
 rationale='This is part of the core toolchain'
 pkgname=linux-headers
 pkgver=5.10.17
-pkgrel=1
+pkgrel=2
 pkgdesc='System headers'
 arch=(x86_64)
 url='http://www.kernel.org'
 license=(GPL2)
-groups=(base)
+groups=(core-dev)
 depends=()
 makedepends=()
 options=()
@@ -34,7 +34,7 @@ build() {
 }
 
 package() {
-    cd "${srcdir}/linux-${pkgver}/dest/usr" || return 1
+    cd "${srcdir}/linux-${pkgver}/dest" || return 1
     set -o pipefail
-    find include -not -type d -name "*.h" | cpio -dump "${pkgdir}"
+    find usr -not -type d -name "*.h" | cpio -dump "${pkgdir}"
 }

--- a/packages/llvm/ChangeLog
+++ b/packages/llvm/ChangeLog
@@ -1,3 +1,10 @@
+2021-03-21  Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
+
+	* 11.1.0-5 :
+	Add additional modules and split out runtime libs
+	Add to new group core-dev
+	Install to prefix /usr
+
 2021-03-18  Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
 
 	* 11.1.0-4 :

--- a/packages/llvm/PKGBUILD
+++ b/packages/llvm/PKGBUILD
@@ -2,14 +2,14 @@
 # shellcheck disable=SC2034,SC2154,SC2068
 # Maintainer: Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
 
-pkgname=llvm
+pkgname=(llvm llvm-runtime-libs)
 pkgver=11.1.0
-pkgrel=4
+pkgrel=5
 pkgdesc='A collection of modular and reusable compiler and toolchain technologies.'
 arch=('x86_64')
 url='htps://llvm.org'
 license=(Apache)
-groups=('base')
+groups=()
 depends=(musl musl-dev)
 makedepends=(cmake git ninja zlib-dev)
 options=()
@@ -32,14 +32,10 @@ build() {
         -e 's@strtoll_l@strtoll@g' \
         -e '/strtoll/s@, _LIBCPP_GET_C_LOCALE@@' \
         libcxx/include/locale
-    sed -i \
-        -e 's@/usr/local/include@/local/include@' \
-        clang/lib/Driver/ToolChains/Linux.cpp
-    sed -i 's@/usr/local/include@/local/include@' llvm/CMakeLists.txt
     install -d build
     cd build || return 1
     cmake -G Ninja -Wno-dev \
-        -DCMAKE_INSTALL_PREFIX='' \
+        -DCMAKE_INSTALL_PREFIX=/usr \
         -DCMAKE_BUILD_TYPE=Release \
         -DCLANG_BUILD_EXAMPLES=OFF \
         -DCLANG_DEFAULT_CXX_STDLIB='libc++' \
@@ -56,6 +52,7 @@ build() {
         -DLLVM_DEFAULT_TARGET_TRIPLE='x86_64-unknown-linux-musl' \
         -DLLVM_DISTRIBUTION_COMPONENTS='clang;clang-resource-headers;lld;LTO;compiler-rt;addr2line;llvm-strip;ar;objcopy;objdump;nm;ranlib;size;strings;strip;unwind;cxx;cxxabi' \
         -DLLVM_ENABLE_LIBCXX=ON \
+        -DLLVM_ENABLE_RTTI=ON \
         -DLLVM_ENABLE_PROJECTS='lld;clang;compiler-rt;libunwind;libcxx;libcxxabi' \
         -DLLVM_ENABLE_TERMINFO=OFF \
         -DLLVM_HOST_TRIPLE='x86_64-unknown-linux-musl' \
@@ -67,14 +64,43 @@ build() {
     cmake --build .
 }
 
-package() {
+package_llvm() {
+    pkgfiles=(
+        usr/bin
+        usr/include
+        usr/lib/*.a
+        usr/lib/*.so
+        usr/lib/clang
+    )
+    depends=(
+        "ld-musl-$(arch).so.1"
+        libLTO.so.11
+        libc++.so.1
+        libc++abi.so.1
+        libunwind.so.1
+    )
+    groups=(core-dev)
     cd_unpacked_src
     cd build || return 1
-    export DESTDIR="${pkgdir}"
+    export DESTDIR="${pkgdirbase}/dest"
     cmake --build . --target install-distribution
-    ln -s libunwind.a "${pkgdir}/lib/libgcc_s.a"
-    ln -s lld "${pkgdir}/bin/ld"
-    ln -s clang "${pkgdir}/bin/cc"
-    ln -s clang++ "${pkgdir}/bin/c++"
-    rm -rf "${pkgdir:?}/usr"
+    std_split_package
+    ln -s libunwind.a "${pkgdir}/usr/lib/libgcc_s.a"
+    ln -s lld "${pkgdir}/usr/bin/ld"
+    ln -s clang "${pkgdir}/usr/bin/cc"
+    ln -s clang++ "${pkgdir}/usr/bin/c++"
+}
+
+package_llvm-runtime-libs() {
+    pkgfiles=(
+        usr/lib/*.so.*
+    )
+    depends=("ld-musl-$(arch).so.1")
+    provides=(
+        libLTO.so.11
+        libc++.so.1
+        libc++abi.so.1
+        libunwind.so.1
+    )
+    std_split_package
 }

--- a/packages/musl/ChangeLog
+++ b/packages/musl/ChangeLog
@@ -1,3 +1,9 @@
+2021-04-08  Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
+
+	* 1.2.2-3 :
+	Add to groups core and core-dev for musl and musl-dev respectively
+	Switch to /usr as main prefix
+
 2021-02-21  Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
 
 	* 1.2.2-2 :
@@ -6,7 +12,7 @@
 2021-02-20  Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
 
 	* 1.2.2-1 :
-    Upgrade to 1.2.2
+	Upgrade to 1.2.2
 
 2019-04-10  Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
 

--- a/packages/musl/PKGBUILD
+++ b/packages/musl/PKGBUILD
@@ -5,12 +5,12 @@
 rationale='This is part of the core toolchain'
 pkgname=(musl musl-dev)
 pkgver=1.2.2
-pkgrel=2
+pkgrel=3
 pkgdesc='An implementation of the C/POSIX standard library.'
-arch=('x86_64')
+arch=(x86_64)
 url='https://musl.libc.org'
 license=(LGPL BSD)
-groups=('base')
+groups=(core)
 depends=()
 makedepends=()
 options=()
@@ -23,38 +23,32 @@ sha256sums=(
 )
 
 build() {
-    cd "${srcdir}/${pkgbase}-${pkgver}" || return || return 1
+    cd_unpacked_src
     unset CFLAGS CXXFLAGS
-    ./configure --prefix=/
+    ./configure --prefix=/usr \
+        --syslibdir=/lib
     make
 }
 
 package_musl() {
     pkgfiles=(
-        bin/ldd
-        lib/libc.so
+        usr/lib/libc.so
         "lib/ld-musl-$(arch).so.1"
     )
+    provides=("ld-musl-$(arch).so.1")
 
-    cd "${srcdir}/${pkgbase}-${pkgver}" || return || return 1
-    make DESTDIR="${pkgdirbase}/dest" install
-    cd "${pkgdirbase}/dest" || return || return 1
-    install -d bin
-    ln -sf ../lib/libc.so bin/ldd
-    set -o pipefail
-    # shellcheck disable=SC2068
-    find ${pkgfiles[@]} | cpio -dump "${pkgdir}"
+    std_package
+    install -d "${pkgdir}"/usr/bin
+    ln -sf /usr/lib/libc.so "${pkgdir}"/usr/bin/ldd
 }
 
 package_musl-dev() {
     pkgfiles=(
-        include
-        lib/*.a
-        lib/*.o
+        usr/include
+        usr/lib/*.a
+        usr/lib/*.o
     )
-    depends=(musl linux-headers)
-    cd "${pkgdirbase}/dest" || return || return 1
-    set -o pipefail
-    # shellcheck disable=SC2068
-    find ${pkgfiles[@]} | cpio -dump "${pkgdir}"
+    depends=("musl=${pkgver}" linux-headers)
+    groups=(core-dev)
+    std_split_package
 }


### PR DESCRIPTION
Mere started out without using /usr for much, on the basis that /usr
is a historical artifact that has no particular meaning. The experiment
worked well, but going forward, it appears that /usr is still expected
and comfortable for most people, there are a few workarounds that we
have to do to ignore it (technically it still existed anyway) and the
benefits of doing so are minimal at best.

Avoid unnecessarily suprising new users by keeping /usr as the main
installation prefix.