### PR TITLE
Improvements to build scripts and containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
-FROM mere/base
+FROM scratch as build
 
-RUN pacman -Syu --noconfirm && \
-    find /var/cache/pacman -not -type d -delete
+ADD busybox-1.32.1-4-x86_64.pkg.tar.xz \
+    pacman-5.2.2-2-x86_64.pkg.tar.xz \
+    /
+
+RUN install -d /tmp/system/var/lib/pacman && \
+    pacman -r /tmp/system -Sy base-layout busybox pacman --noconfirm && \
+    rm -rf /tmp/system/var/cache/pacman/pkg/*
+
+FROM scratch
+
+COPY --from=build /tmp/system /
 
 CMD ["/bin/sh"]

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,13 +1,17 @@
 FROM mere/base
 
+RUN rm -f /usr/local && chmod 755 /usr
+
 COPY packages/pacman/pacman-dev.conf /etc/pacman.conf
-COPY scripts/build-in-docker.sh /local/bin
+COPY scripts/build-in-docker.sh /usr/local/bin/build-in-docker.sh
 
 RUN install -d /mere/pkgs && \
     touch /mere/pkgs/buildlocal.db && \
     pacman -Syu --noconfirm && \
-    pacman -Sy --noconfirm build-essential && \
-    chmod +x /local/bin/build-in-docker.sh && \
+    pacman -Sy --noconfirm build-essential sudo && \
+    chmod +x /usr/local/bin/build-in-docker.sh && \
+    rm -rf /var/lib/pacman/sync && \
+    printf 'merebuild ALL=(ALL) NOPASSWD: ALL\n' >>/etc/sudoers && \
     find /var/cache/pacman -not -type d -delete
 
 WORKDIR /src

--- a/scripts/build-in-docker.sh
+++ b/scripts/build-in-docker.sh
@@ -3,13 +3,13 @@
 cd /src
 
 touch /mere/pkgs/buildlocal.db
-pacman -Syu --noconfirm
+sudo pacman -Syu --noconfirm
 makepkg -Ls --noconfirm
 makepkg --allsource
 mv ./*.src.tar.xz /mere/pkgs/
 
 find /tmp/staging -name "*.pkg*" | while read -r file ; do
     cp -a "$file" /mere/pkgs/
-    pacman -Dk >/dev/null
+    sudo pacman -Dk >/dev/null
     repo-add -R /mere/pkgs/buildlocal.db.tar.gz "/mere/pkgs/${file##*/}"
 done

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,28 +2,65 @@
 
 usage() {
     printf '
-Usage: %s <pkgdir>
+Usage: %s <pkgdir> [cmd]
 
   <pkgdir>   Identifies a directory containing, at minimum, a PKGBUILD file.
              The directory may also contain a ChangeLog file and additional
              source files required for the build.
+
+  [cmd]      Optional command to run inside the container. E.g., /bin/sh.
+             The default is /usr/local/bin/build-in-docker.sh
 ' "$0"
 }
 
-if [ -z "$1" ] || [ ! -d "$1" ] ; then
+# A really simple implementation of realpath for systems that don't have it
+realpath_cd () {
+    cd "$1" || return 1
+    pwd -P
+    cd -
+}
+
+bad_pkgdir() {
     usage
-    printf 'Missing or invalid directory. pkgdir argument: %s\n' "${pkgdir}"
+    printf '\nMissing or invalid directory: %s\n' "$1"
+    exit 2
+}
+
+if [ -z "$1" ] || [ ! -d "$1" ] ; then
+    bad_pkgdir "$1"
 else
+    command -v realpath >/dev/null || alias realpath='realpath_cd'
     pkgdir=$(realpath "$1")
     shift
 fi
 
-cmd=/local/bin/build-in-docker.sh
+cmd=/usr/local/bin/build-in-docker.sh
 [ -n "$1" ] && cmd="$1"
+[ -d "${pkgdir}/pkg" ] && chmod 755 "${pkgdir}/pkg"
+
+MEREDIR="${HOME}/.mere"
+uid=$(id -u)
+gid=$(id -g)
+
+install -d "${MEREDIR}/logs"
+install -d "${MEREDIR}/pkgs"
+install -d "${MEREDIR}/sources"
+
+# These two lines assume the script will be run from the top of the merelinux
+# source directory. May revisit this in the future.
+cp packages/base-layout/passwd "$MEREDIR"
+cp packages/base-layout/group "$MEREDIR"
+
+printf 'merebuild:x:%s:%s:Mere Build User,,,:/src:/bin/sh' \
+    "$uid" "$gid" >>"${MEREDIR}/passwd"
+printf 'merebuild:x:%s:merebuild' \
+    "$uid" "$gid" >>"${MEREDIR}/group"
 
 docker run -it --rm \
-    -v "${pkgdir}":/src \
-    -v /mere/logs:/mere/logs \
-    -v /mere/pkgs:/mere/pkgs \
-    -v /mere/sources:/mere/sources \
+    -e PACKAGER="$MERE_PACKAGER" \
+    -v "$pkgdir":/src \
+    -v "$MEREDIR":/mere \
+    -v "${MEREDIR}/passwd":/etc/passwd \
+    -v "${MEREDIR}/group":/etc/group \
+    -u "${uid}:${gid}" \
     mere/dev:latest "$cmd"


### PR DESCRIPTION
- Updates to recent versions of packages from the testing channel
- Makes `scripts/build.sh` slightly more portable. For example, pending
  release of the next version of docker with fixes like
  [this one](https://github.com/moby/moby/pull/42054), it should be
  possible to build mere packages on Mac hosts.
- Use a non-privileged user in the container and map that user to the
  uid and gid of the host system user so that created files in the
  mounted volumes will be owned by the host user.