### PR TITLE
Fix addition of group line for build.sh

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -54,7 +54,7 @@ cp packages/base-layout/group "$MEREDIR"
 printf 'merebuild:x:%s:%s:Mere Build User,,,:/src:/bin/sh' \
     "$uid" "$gid" >>"${MEREDIR}/passwd"
 printf 'merebuild:x:%s:merebuild' \
-    "$uid" "$gid" >>"${MEREDIR}/group"
+    "$gid" >>"${MEREDIR}/group"
 
 docker run -it --rm \
     -e PACKAGER="$MERE_PACKAGER" \


### PR DESCRIPTION
The format string only expects one value, but two were passed.