### PR TITLE
Updates to ci-upload script

### DIFF
--- a/packages/cmake/ChangeLog
+++ b/packages/cmake/ChangeLog
@@ -1,3 +1,8 @@
+2021-08-15  Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
+
+	* 3.19.5-3 :
+	Bump version to trigger a new build and release with new scripts
+
 2021-04-08  Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
 
 	* 3.19.5-2 :

--- a/packages/cmake/PKGBUILD
+++ b/packages/cmake/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=cmake
 pkgver=3.19.5
-pkgrel=2
+pkgrel=3
 pkgdesc='The CMake toolsuite for building, testing and packaging software.'
 arch=('x86_64')
 url='https://cmake.org'

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -38,7 +38,8 @@ cmd=/usr/local/bin/build-in-docker.sh
 [ -n "$1" ] && cmd="$1"
 [ -d "${pkgdir}/pkg" ] && chmod 755 "${pkgdir}/pkg"
 
-MEREDIR="${HOME}/.mere"
+MEREDIR="${MEREDIR:-${HOME}/.mere}"
+printf 'MEREDIR is: %s\n' "$MEREDIR"
 uid=$(id -u)
 gid=$(id -g)
 

--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2154,SC1090
 . "$CIRCLE_WORKING_DIRECTORY"/.env
 if [ -n "$pkg" ] ; then
-    ./scripts/build.sh "$pkg"
+    MEREDIR="$(pwd)/.mere" ./scripts/build.sh "$pkg"
 else
     printf 'No packages are required to build in this commit.\n'
 fi

--- a/scripts/ci-upload.sh
+++ b/scripts/ci-upload.sh
@@ -1,28 +1,40 @@
-#!/bin/bash -e
+#!/bin/bash -xe
+sudo pip install awscli
+
 bn="$(git rev-parse --abbrev-ref HEAD)"
-if [ "$bn" != 'master' ]; then
-    printf 'Skipping for branch: %s\n' "$bn"
-    exit 0
-fi
+case "$bn" in
+    master)
+        # install pacman-build
+        curl -LO http://pkgs.merelinux.org/stable/pacman-latest-x86_64.pkg.tar.xz
+        tar -xf pacman-latest-x86_64.pkg.tar.xz 2>/dev/null
+        install -d ./var/lib/pacman
+        ./bin/pacman -S --config etc/pacman.conf -y -r . --noconfirm --overwrite pacman-build
+        sed -i '/bsdtar -xf .*dbfile/s@-C@--no-fflags -C@' bin/repo-add
 
-curl -LO http://pkgs.merelinux.org/stable/pacman-latest-x86_64.pkg.tar.xz
-tar -xf pacman-latest-x86_64.pkg.tar.xz
-install -d ./var/lib/pacman
-./bin/pacman -S --config etc/pacman.conf -y -r . --noconfirm --overwrite pacman-build
+        # Sync down existing files in the staging repo
+        install -d pkgs/testing pkgs/staging
+        aws s3 sync s3://pkgs.merelinux.org/staging/ pkgs/staging/
 
-pip install awscli
+        # Grab the testing dbs
+        curl -fsL http://pkgs.merelinux.org/testing/main.db.tar.gz \
+            -o pkgs/testing/main.db.tar.gz
+        curl -fsL http://pkgs.merelinux.org/testing/main.files.tar.gz \
+            -o pkgs/testing/main.files.tar.gz
 
-install -d pkgs/testing
-curl -fsL http://pkgs.merelinux.org/testing/main.db.tar.gz \
-    -o pkgs/testing/main.db.tar.gz
-curl -fsL http://pkgs.merelinux.org/testing/main.files.tar.gz \
-    -o pkgs/testing/main.files.tar.gz
+        # Copy over the staging files to testing
+        find "pkgs/staging" -name "*.pkg*" | while read -r file ; do
+            mv -v "$file" pkgs/testing
+            ./bin/repo-add -R pkgs/testing/main.db.tar.gz "pkgs/testing/${file##*/}"
+        done
+        find pkgs/staging -name "*.src.tar.xz" -exec mv -v '{}' pkgs/staging/ \;
 
-sed -i '/bsdtar -xf .*dbfile/s@-C@--no-fflags -C@' bin/repo-add
-find "${HOME}/.mere/tmp/staging" -name "*.src.tar.xz" -exec mv '{}' pkgs/testing/ \;
-find "${HOME}/.mere/tmp/staging" -name "*.pkg*" | while read -r file ; do
-    mv "$file" pkgs/testing
-    ./bin/repo-add -R pkgs/testing/main.db.tar.gz "pkgs/testing/${file##*/}"
-done
+        aws s3 sync pkgs s3://pkgs.merelinux.org
+        aws s3 sync --delete pkgs/staging/ s3://pkgs.merelinux.org/pkgs/staging/
+        ;;
+    *)
+        install -d pkgs/staging
+        find "$(pwd)/.mere/pkgs" -type f -exec mv -v '{}' pkgs/staging/ \;
+        aws s3 sync pkgs s3://pkgs.merelinux.org
+        ;;
+esac
 
-aws s3 sync pkgs s3://pkgs.merelinux.org


### PR DESCRIPTION
Pipeline jobs from pull requests will already build and test packages.
We can avoid building them again on master then, if we can save the archives
from successful pipelines.

Bump the cmake version so we can fully test the pipelines