### PR TITLE
Fix bug in master pipeline upload stage

### DIFF
--- a/scripts/ci-upload.sh
+++ b/scripts/ci-upload.sh
@@ -5,10 +5,14 @@ bn="$(git rev-parse --abbrev-ref HEAD)"
 case "$bn" in
     master)
         # install pacman-build
+        install -d /tmp/pacman
         curl -LO http://pkgs.merelinux.org/stable/pacman-latest-x86_64.pkg.tar.xz
-        tar -xf pacman-latest-x86_64.pkg.tar.xz 2>/dev/null
+        tar -C /tmp/pacman -xf pacman-latest-x86_64.pkg.tar.xz 2>/dev/null
+
         install -d ./var/lib/pacman
-        sudo ./bin/pacman -S --config etc/pacman.conf -y -r . --noconfirm --overwrite pacman-build
+        sudo /tmp/pacman/bin/pacman -Sy
+        sudo /tmp/pacman/bin/pacman -Sy --config /tmp/pacman/etc/pacman.conf \
+            -r . --noconfirm pacman-build
         sudo sed -i '/bsdtar -xf .*dbfile/s@-C@--no-fflags -C@' bin/repo-add
 
         # Sync down existing files in the staging repo
@@ -39,4 +43,3 @@ case "$bn" in
         fi
         ;;
 esac
-


### PR DESCRIPTION
Install the temporary pacman to /tmp first, then use it to install
pacman-build (and pacman again) to the local directory, avoiding the
--overwrite flag which seems to not work as expected on first use.