### PR TITLE
Sleep after calling `aws s3 rm`

### DIFF
--- a/scripts/ci-upload.sh
+++ b/scripts/ci-upload.sh
@@ -33,6 +33,7 @@ case "$bn" in
 
         aws s3 sync pkgs s3://pkgs.merelinux.org
         aws s3 rm --recursive s3://pkgs.merelinux.org/pkgs/staging/
+        sleep 5
         ;;
     *)
         install -d pkgs/staging


### PR DESCRIPTION
Something about running this command in the pipeline is causing it to
appear to succeed, but not actually do anything. Testing a sleep to see
if that changes anything.