### PR TITLE
Fix the `aws s3 rm` issue

### DIFF
--- a/scripts/ci-upload.sh
+++ b/scripts/ci-upload.sh
@@ -32,8 +32,7 @@ case "$bn" in
         find pkgs/staging -name "*.src.tar.xz" -exec mv -v '{}' pkgs/testing/ \;
 
         aws s3 sync pkgs s3://pkgs.merelinux.org
-        aws s3 rm --recursive s3://pkgs.merelinux.org/pkgs/staging/
-        sleep 5
+        aws s3 rm --recursive s3://pkgs.merelinux.org/staging/
         ;;
     *)
         install -d pkgs/staging


### PR DESCRIPTION
The previous sleep was unnecessary - there was a typo on the path