### PR TITLE
Fix bug in build.sh

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/sh -xe
 
 usage() {
     printf '
@@ -17,7 +17,7 @@ Usage: %s <pkgdir> [cmd]
 realpath_cd () {
     cd "$1" || return 1
     pwd -P
-    cd -
+    cd - >/dev/null 2>&1 || return 1
 }
 
 bad_pkgdir() {


### PR DESCRIPTION
realpath_cd was printing out the directory that was changed to when
calling `cd -` in addition to the output from `pwd -P`.

Also adding -x to the top of the script for gathering info about the
pipeline environment. The docker builds need to be done with at least a
fake root account so that permissions in the generated packages are
correct. So this begins and investigation into the correct solution
there.