### PR TITLE
Rename the testing db from main to testing

### DIFF
--- a/buildpkg.sh
+++ b/buildpkg.sh
@@ -57,6 +57,7 @@ if [ "$uid" = '0' ]; then
         -v "$pkgdir":/src \
         -v "$MEREDIR":/mere \
         -v "$(pwd)"/dev-scripts:/usr/local/bin \
+        -v "$(pwd)"/packages/pacman/pacman-dev.conf:/etc/pacman.conf \
         mere/dev:latest "$cmd"
 else
     printf 'merebuild:x:%s:%s:Mere Build User,,,:/src:/bin/sh\n' \
@@ -70,6 +71,7 @@ else
         -v "$MEREDIR":/mere \
         -v "${MEREDIR}/passwd":/etc/passwd \
         -v "${MEREDIR}/group":/etc/group \
+        -v "$(pwd)"/packages/pacman/pacman-dev.conf:/etc/pacman.conf \
         -v "$(pwd)"/dev-scripts:/usr/local/bin \
         -u "${uid}:${gid}" \
         mere/dev:latest "$cmd"

--- a/ci-scripts/ci-upload.sh
+++ b/ci-scripts/ci-upload.sh
@@ -27,15 +27,15 @@ case "$bn" in
         aws s3 sync "s3://pkgs.merelinux.org/${prnum}/" staging/
 
         # Grab the testing dbs
-        curl -fsL http://pkgs.merelinux.org/testing/main.db.tar.gz \
-            -o pkgs/testing/main.db.tar.gz
-        curl -fsL http://pkgs.merelinux.org/testing/main.files.tar.gz \
-            -o pkgs/testing/main.files.tar.gz
+        curl -fsL http://pkgs.merelinux.org/testing/testing.db.tar.gz \
+            -o pkgs/testing/testing.db.tar.gz
+        curl -fsL http://pkgs.merelinux.org/testing/testing.files.tar.gz \
+            -o pkgs/testing/testing.files.tar.gz
 
         # Copy over the staging files to testing
         find staging -name "*.pkg*" | while read -r file ; do
             mv -v "$file" pkgs/testing
-            ./bin/repo-add -R pkgs/testing/main.db.tar.gz "pkgs/testing/${file##*/}"
+            ./bin/repo-add -R pkgs/testing/testing.db.tar.gz "pkgs/testing/${file##*/}"
         done
         find staging -name "*.src.tar.xz" -exec mv -v '{}' pkgs/testing/ \;
 

--- a/packages/pacman/pacman-dev.conf
+++ b/packages/pacman/pacman-dev.conf
@@ -1,10 +1,10 @@
 [options]
-HoldPkg      = pacman busybox busybox-static
+HoldPkg      = pacman busybox
 Architecture = auto
 CheckSpace
 
 [buildlocal]
 Server = file:///mere/pkgs
 
-[main]
+[testing]
 Server = http://pkgs.merelinux.org/testing


### PR DESCRIPTION
Refs #166

This will avoid naming conflicts with stable, allowing a developer to
have both repositories enabled on a single machine.

Will continue to evaluate repository layou and shape, using
https://wiki.archlinux.org/index.php/official_repositories as a source
of inspiration.