### PR TITLE
Refactor buildpkg.sh for the sake of permissions

### DIFF
--- a/dev-scripts/gen
+++ b/dev-scripts/gen
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+gen_changelog
+gen_sums

--- a/dev-scripts/gen_changelog
+++ b/dev-scripts/gen_changelog
@@ -32,11 +32,14 @@ parse_oldstyle() {
             entry=$(printf '%s (%s)\n%s\n' "$version" "$date" "$logline")
         fi
     done < "${pkgdir}/${changelog}"
+    # Print the last entry
+    [ -n "$entry" ] && printf '%s\n' "$entry"
 }
 
 set -o pipefail
 
-pkgdir="$1"
+pkgdir='.'
+[ -n "$1" ] && pkgdir="$1"
 if [ ! -d "$pkgdir" ]; then
     printf 'Missing directory: %s\n' "$pkgdir"
     exit 1
@@ -46,11 +49,12 @@ fi
 . "${pkgdir}/PKGBUILD"
 
 [ -n "$changelog" ] || changelog='ChangeLog'
+[ -e "${pkgdir}/${changelog}" ] || touch "${pkgdir}/${changelog}"
 
 if head -n1 "${pkgdir}/${changelog}" | \
    grep -qE '^\d{4}-\d{2}-\d{2}.*<[A-z\d._%+-]+@[A-z\d.-]+\.[A-z]{2,}>$'; then
    content=$(parse_oldstyle)
-   printf '%s\s' "$content" >"${pkgdir}/${changelog}"
+   printf '%s\n' "$content" >"${pkgdir}/${changelog}"
 fi
 
 declare -A releases


### PR DESCRIPTION
Challenges:
- Building as a non-root user will create packages with incorrect
  permissions
- Buiding as root with the in-tree packages directory will leave
  root-owned files and directories in the git-managed tree
- Scripts to calculate sums and generate changelogs require tools that
  may not be present on the host system and can easily be managed in the
  development container, so it's nicer to run them there. However,
  running as root will again create or modify files as the root user and
  can cause permission issues for the git-managed tree.

Decisions:
- For the special dev-scripts actions, auto-generating sums and
  changelogs, run as an unprivileged user with the current tree mounted.
  This will make changes with the current user's uid/gid and operate on
  the git-managed files.
- For other actions, including actual package builds, run as root and
  create a temporary build directory in the host system's tmpdir
  location.
- Add a simple 'gen' script that combines gen_changelog and gen_sums as
  a single command.