### PR TITLE
Excplicitly clear the shell's path cache via hash

### DIFF
--- a/dev-scripts/build-in-docker
+++ b/dev-scripts/build-in-docker
@@ -4,6 +4,8 @@ cd /src
 
 touch /mere/pkgs/buildlocal.db
 sudo pacman -Syu --noconfirm
+# Clear the shell's cached paths of binaries, in case something moved
+hash -r
 makepkg -Ls --noconfirm
 makepkg --allsource
 mv ./*.src.tar.xz /mere/pkgs/


### PR DESCRIPTION
In the build-in-docker script, after upgrading, some previous paths may
have changed. busybox's sh appears to cache paths it finds. Clear the
paths explicitly to avoid potential 'not found' issues if binary paths
have changed during upgrades.