### PR TITLE
[mksh] Move man page to /usr/share/man

### DIFF
--- a/dev-scripts/gen_changelog
+++ b/dev-scripts/gen_changelog
@@ -3,7 +3,7 @@
 parse_newstyle() {
     while IFS= read -r line; do
         if printf '%s' "$line" | \
-            grep -qE '^\d+.*-\d+ \(\d{4}-\d{2}-\d{2}\)'; then
+            grep -qE '^[A-z\d]+.*-\d+ \(\d{4}-\d{2}-\d{2}\)'; then
             version=$(printf '%s' "$line" | cut -d' ' -f1)
             logline=''
         elif printf '%s' "$line" | grep -qE '^\t[A-z]+'; then

--- a/packages/mksh/ChangeLog
+++ b/packages/mksh/ChangeLog
@@ -1,34 +1,31 @@
-2021-08-19  Jeremy Huntwork <jeremy@merelinux.org>
+R59c-3 (2021-08-31)
 
-	* R59c-2 :
+	Move man page to /usr/share/man
+
+R59c-2 (2021-08-19)
+
 	Add to core group
 
-2021-02-28  Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
+R59c-1 (2021-02-28)
 
-	* R59c-1 :
 	Upgrade to R59c
 
-2018-11-18  Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
+R56c-1 (2018-11-18)
 
-	* R56c-1 :
 	Upgrade to R56c
 
-2017-05-26 Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
+R55-1 (2017-05-26)
 
-	* R55-1 :
 	Upgrade to R55
 
-2015-08-11 Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
+R51-1 (2015-08-11)
 
-	* R51-1 :
 	Upgrade to R51
 
-2015-03-16 Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
+R50e-1 (2015-03-16)
 
-	* R50e-1 :
 	Upgrade to R50e
 
-2014-05-28 Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
+R49-1 (2014-05-28)
 
-	* R49-1 :
 	Initial version

--- a/packages/mksh/PKGBUILD
+++ b/packages/mksh/PKGBUILD
@@ -1,10 +1,9 @@
 #!/bin/bash
 # shellcheck disable=SC2034,SC2154,SC2068
-# Maintainer: Jeremy Huntwork <jeremy@merelinux.org>
 
 pkgname=mksh
 pkgver=R59c
-pkgrel=2
+pkgrel=3
 pkgdesc='The MirBSD Korn Shell'
 arch=(x86_64)
 url='https://www.mirbsd.org/mksh.htm'
@@ -31,7 +30,7 @@ build() {
 package() {
     cd_unpacked_src
     install -d "${pkgdir}/bin"
-    install -d "${pkgdir}/share/man/man1"
+    install -d "${pkgdir}/usr/share/man/man1"
     install -m 0755 mksh "${pkgdir}/bin/"
-    install -c -o root -g bin -m 444 lksh.1 mksh.1 "${pkgdir}/share/man/man1/"
+    install -c -o root -g bin -m 444 lksh.1 mksh.1 "${pkgdir}/usr/share/man/man1/"
 }


### PR DESCRIPTION
Also adjust the version regex in gen_changelog to support mksh's
verisons.