### PR TITLE
[ncurses] Fix ncursesw headers

### DIFF
--- a/packages/ncurses/ChangeLog
+++ b/packages/ncurses/ChangeLog
@@ -1,39 +1,35 @@
-2021-04-09  Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
+6.2-3 (2021-08-31)
 
-	* 6.2-2 :
+	Fix ncursesw headers. Some code looks for an ncursesw directory.
+
+6.2-2 (2021-04-09)
+
 	Use /usr for prefix
 
-2021-02-21  Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
+6.2-1 (2021-02-21)
 
-	* 6.2-1 :
 	Upgrade to 6.2
 
-2019-04-11  Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
+6.1-2 (2019-04-11)
 
-	* 6.1-2 :
 	Update mirror and version of termcap source
 
-2018-11-25  Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
+6.1-1 (2018-11-25)
 
-	* 6.1-1 :
 	Upgrade to 6.1
 
-2017-03-30 Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
+6.0-1 (2017-03-30)
 
-	* 6.0-1 :
 	Upgrade to 6.0
 
-2015-03-20 Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
+5.9-3 (2015-03-20)
 
-	* 5.9-3 :
 	Add wide character support
 
-2015-03-20 Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
+5.9-2 (2015-03-20)
 
-	* 5.9-2 :
 	Fix libncurses dependencies
 
-2013-08-01 Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
+5.9-1 (2013-08-01)
 
-	* 5.9-1 :
 	Initial version

--- a/packages/ncurses/PKGBUILD
+++ b/packages/ncurses/PKGBUILD
@@ -1,6 +1,5 @@
 #!/bin/bash
 # shellcheck disable=SC2034,SC2154,SC2068
-# Maintainer: Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
 
 rationale='The packaging of ncurses for the final system requires utilities that ship with ncurses, so it has a self-dependency'
 pkgname=(
@@ -9,7 +8,7 @@ pkgname=(
     libncurses-dev
 )
 pkgver=6.2
-pkgrel=2
+pkgrel=3
 pkgdesc='An API for writing text-based user interfaces'
 arch=(x86_64)
 url='http://www.gnu.org/software/ncurses'
@@ -29,7 +28,7 @@ source=(
 )
 sha256sums=(
     30306e0c76e0f9f1f0de987cf1c82a5c21e1ce6568b9227f7da5b71cbea86c9d
-    1e02c6f809d4ff7b2742c05fcddd6b19e8bdc412414d6003479eb62a0c87c6f6
+    11007fdad0867408cd14b93ec4ec4eb4f39370bbf0520957c9826db4fa6d66fd
 )
 
 
@@ -63,7 +62,11 @@ package_ncurses() {
         ln -s lib${lib}w.a usr/lib/lib${lib}.a
     done
     ln -s libncurses.a usr/lib/libcurses.a
-    ln -s ncursesw usr/include/ncurses
+    install -d usr/include/ncursesw
+    find usr/include -type f | while read -r file; do
+        bn=${file##*/}
+        ln -sv "../${bn}" usr/include/ncursesw/
+    done
 
     find ${pkgfiles[@]} | cpio -dump --quiet "$pkgdir"
     # ncurses6w-config is in -dev and clear/reset are in busybox


### PR DESCRIPTION
Some code looks for an ncursesw directory, so satisfy it via symlinks.
The previous symlink was broken as the headers had been installed
directly in the /usr/include directory, instead of /usr/include/ncurses