### PR TITLE
[gptfdisk] Upgrade to 1.0.8

### DIFF
--- a/packages/gptfdisk/ChangeLog
+++ b/packages/gptfdisk/ChangeLog
@@ -1,14 +1,18 @@
-2021-02-27  Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
+1.0.8-1 (2021-08-31)
 
-	* 1.0.6-2 :
+	Upgrade to 1.0.8
+	Remove from base group
+	Install binaries to /usr/sbin instead of /bin
+	Add man pages
+
+1.0.6-2 (2021-02-27)
+
 	Build with latest musl, popt and libuuid
 
-2018-11-17  Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
+1.0.4-1 (2018-11-17)
 
-	* 1.0.4-1 :
 	Initial version
 
-2017-05-26 Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
+1.0.1-1 (2017-05-26)
 
-	* 1.0.1-1 :
 	Initial version

--- a/packages/gptfdisk/PKGBUILD
+++ b/packages/gptfdisk/PKGBUILD
@@ -1,10 +1,9 @@
 #!/bin/bash
 # shellcheck disable=SC2034,SC2154,SC2068
-# Maintainer: Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
 
 pkgname=gptfdisk
-pkgver=1.0.6
-pkgrel=2
+pkgver=1.0.8
+pkgrel=1
 pkgdesc='A set of text-mode partitioning tools'
 arch=(x86_64)
 url='http://www.rodsbooks.com/gdisk'
@@ -23,21 +22,21 @@ source=(
 )
 
 sha256sums=(
-    ddc551d643a53f0bd4440345d3ae32c49b04a797e9c01036ea460b6bb4168ca8
+    95d19856f004dabc4b8c342b2612e8d0a9eebdd52004297188369f152e9dc6df
 )
 
 
 build() {
-    cd "${srcdir}/${pkgname}-${pkgver}" || return 1
-    CXX=c++ CXXFLAGS+=' -static -I/include/ncursesw' \
+    cd_unpacked_src
+    CXX=c++ CXXFLAGS+=' -static' \
         LDFLAGS='-static -Wl,-static -lunwind -lc++abi' MAKEFLAGS='' make
 }
 
 package() {
-    options=()
-    cd "${srcdir}/${pkgname}-${pkgver}" || return 1
-    install -d "${pkgdir}/bin"
+    cd_unpacked_src
+    install -d "${pkgdir}/usr/sbin" "${pkgdir}/usr/share/man/man8"
     for bin in cgdisk gdisk sgdisk fixparts ; do
-        install -m0755 $bin "${pkgdir}/bin/"
+        install -m0755 $bin "${pkgdir}/usr/sbin/"
+        install -m0644 "${bin}.8" "${pkgdir}/usr/share/man/man8/"
     done
 }


### PR DESCRIPTION
Also:
- Remove from base group
- Install binaries to /usr/sbin instead of /bin
- Add man pages