### PR TITLE
Remove last reference to core-dev

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -7,7 +7,7 @@ COPY packages/pacman/pacman-dev.conf /etc/pacman.conf
 RUN install -d /mere/pkgs && \
     touch /mere/pkgs/buildlocal.db && \
     pacman -Syu --noconfirm && \
-    pacman -Sy --noconfirm base-layout busybox core-dev pacman-build sudo && \
+    pacman -Sy --noconfirm base-layout busybox build-base pacman-build sudo && \
     rm -rf /var/lib/pacman/sync && \
     printf 'merebuild ALL=(ALL) NOPASSWD: ALL\n' >>/etc/sudoers && \
     find /var/cache/pacman -not -type d -delete


### PR DESCRIPTION
Using build-base instead. The term 'core' will be used for the main
repository housing the foundation software for Mere Linux. 'base' is
a group of the packages required for all Mere systems, and 'build-base'
is a group of the most common development tools required for compiling
most packages.

Resolves #166