### PR TITLE
[llvm] Build and package readelf

### DIFF
--- a/packages/llvm/ChangeLog
+++ b/packages/llvm/ChangeLog
@@ -1,3 +1,7 @@
+11.1.0-8 (2021-09-08)
+
+	Build and install readelf
+
 11.1.0-7 (2021-09-05)
 
 	Move from core-dev group to build-base group

--- a/packages/llvm/PKGBUILD
+++ b/packages/llvm/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=(llvm llvm-runtime-libs)
 pkgver=11.1.0
-pkgrel=7
+pkgrel=8
 pkgdesc='A collection of modular and reusable compiler and toolchain technologies.'
 arch=('x86_64')
 url='htps://llvm.org'
@@ -16,15 +16,18 @@ changelog=ChangeLog
 
 source=(
     "https://github.com/llvm/llvm-project/releases/download/llvmorg-${pkgver}/llvm-project-${pkgver}.src.tar.xz"
+    "https://reviews.llvm.org/file/data/gzxc6jzljy6hogcbsis4/PHID-FILE-wgfo5g772gdk6n7e2ulf/D82170.diff"
 )
 
 sha256sums=(
     74d2529159fd118c3eac6f90107b5611bccc6f647fdea104024183e8d5e25831
+    2d4f17538cf98be9c85a60917f76d93bc653fbc395dae0389e22ebb7f42e79e3
 )
 
 
 build() {
     cd_unpacked_src
+    patch -Np1 -i "${srcdir}/D82170.diff"
     sed -i \
         -e 's@strtoull_l@strtoull@g' \
         -e '/strtoull/s@, _LIBCPP_GET_C_LOCALE@@' \
@@ -49,7 +52,7 @@ build() {
         -DLIBCXXABI_USE_COMPILER_RT=ON \
         -DLIBCXXABI_USE_LLVM_UNWINDER=ON \
         -DLLVM_DEFAULT_TARGET_TRIPLE='x86_64-unknown-linux-musl' \
-        -DLLVM_DISTRIBUTION_COMPONENTS='clang;clang-resource-headers;lld;LTO;compiler-rt;addr2line;llvm-strip;ar;objcopy;objdump;nm;ranlib;size;strings;strip;unwind;cxx;cxxabi' \
+        -DLLVM_DISTRIBUTION_COMPONENTS='clang;clang-resource-headers;lld;LTO;compiler-rt;addr2line;llvm-readelf;llvm-strip;ar;objcopy;objdump;nm;ranlib;readelf;size;strings;strip;unwind;cxx;cxxabi' \
         -DLLVM_ENABLE_LIBCXX=ON \
         -DLLVM_ENABLE_RTTI=ON \
         -DLLVM_ENABLE_PROJECTS='lld;clang;compiler-rt;libunwind;libcxx;libcxxabi' \


### PR DESCRIPTION
readelf wasn't shipped before, but some tools make use of it.
Specifically, makepkg now uses it for file type information when
choosing how to strip symbols from files