### PR TITLE
Adjust build scripts to sign packages/repo

### DIFF
--- a/buildpkg.sh
+++ b/buildpkg.sh
@@ -73,6 +73,7 @@ case "$cmd" in
         cd - >/dev/null
         trap 'printf "\nBuild directory was: %s\n" $tmpdir' EXIT
         docker run -it --rm \
+            -e SIGNING_KEY \
             -v "$tmpdir":/src \
             -v "$MEREDIR":/mere \
             -v "$(pwd)"/dev-scripts:/usr/local/bin \

--- a/dev-scripts/build-in-docker
+++ b/dev-scripts/build-in-docker
@@ -1,17 +1,37 @@
 #!/bin/sh -e
-
 cd /src
 
 touch /mere/pkgs/buildlocal.db
 sudo pacman -Syu --noconfirm
+
 # Clear the shell's cached paths of binaries, in case something moved
 hash -r
-makepkg -Ls --noconfirm
+
+if [ -n "$SIGNING_KEY" ]; then
+    sign='--sign'
+    reposign='-s'
+
+    # Import the private and public key to the user keyring
+    printf '%s\n' "$SIGNING_KEY" | gpg --import -- -
+
+    # Setup pacman keyring
+    sudo pacman-key --init
+
+    # Add the user's public key
+    gpg --armor --export | pacman-key -a -- -
+
+    # Trust public key
+    pubkey=$(gpg --list-keys --with-colons | grep pub | cut -d: -f5)
+    pacman-key --lsign-key "$pubkey"
+fi
+
+makepkg -Ls --noconfirm $sign
 makepkg --allsource
 mv ./*.src.tar.xz /mere/pkgs/
 
-find /tmp/staging -name "*.pkg*" | while read -r file ; do
+find /tmp/staging -name "*.pkg*" -not -name "*.sig" | while read -r file ; do
     cp -a "$file" /mere/pkgs/
+    [ -f "${file}.sig" ] && cp -a "${file}.sig" /mere/pkgs/
     sudo pacman -Dk >/dev/null
-    repo-add -R /mere/pkgs/buildlocal.db.tar.gz "/mere/pkgs/${file##*/}"
+    repo-add $reposign -R /mere/pkgs/buildlocal.db.tar.gz "/mere/pkgs/${file##*/}"
 done


### PR DESCRIPTION
If the SIGNING_KEY env variable is set, use that as a gpg secret key for
signing packages and repositories.

Fixes #7

Will still need to go through and sign all packages and then set the
default pacman configuration for stable/testing to require signatures.