### PR TITLE
[pacman] Back out gpg support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - run:
           name: Install tools and upgrade
-          command: pacman -Syu --noconfirm git openssh-client shellcheck
+          command: pacman -Sy --noconfirm git openssh-client shellcheck
       - checkout
       - run:
           name: Shellcheck

--- a/buildpkg.sh
+++ b/buildpkg.sh
@@ -73,7 +73,6 @@ case "$cmd" in
         cd - >/dev/null
         trap 'printf "\nBuild directory was: %s\n" $tmpdir' EXIT
         docker run -it --rm \
-            -e SIGNING_KEY \
             -v "$tmpdir":/src \
             -v "$MEREDIR":/mere \
             -v "$(pwd)"/dev-scripts:/usr/local/bin \

--- a/dev-scripts/build-in-docker
+++ b/dev-scripts/build-in-docker
@@ -2,30 +2,13 @@
 cd /src
 
 touch /mere/pkgs/buildlocal.db
-sudo pacman -Syu --noconfirm
+#sudo pacman -Syu --noconfirm
+sudo pacman -Sy
 
 # Clear the shell's cached paths of binaries, in case something moved
 hash -r
 
-if [ -n "$SIGNING_KEY" ]; then
-    sign='--sign'
-    reposign='-s'
-
-    # Import the private and public key to the user keyring
-    printf '%b' "$SIGNING_KEY" | gpg --import -- -
-
-    # Setup pacman keyring
-    sudo pacman-key --init
-
-    # Add the user's public key
-    gpg --armor --export | pacman-key -a -- -
-
-    # Trust public key
-    pubkey=$(gpg --list-keys --with-colons | grep pub | cut -d: -f5)
-    pacman-key --lsign-key "$pubkey"
-fi
-
-makepkg -Ls --noconfirm $sign
+makepkg -Ls --noconfirm
 makepkg --allsource
 mv ./*.src.tar.xz /mere/pkgs/
 
@@ -33,5 +16,5 @@ find /tmp/staging -name "*.pkg*" -not -name "*.sig" | while read -r file ; do
     cp -a "$file" /mere/pkgs/
     [ -f "${file}.sig" ] && cp -a "${file}.sig" /mere/pkgs/
     sudo pacman -Dk >/dev/null
-    repo-add $reposign -R /mere/pkgs/buildlocal.db.tar.gz "/mere/pkgs/${file##*/}"
+    repo-add -R /mere/pkgs/buildlocal.db.tar.gz "/mere/pkgs/${file##*/}"
 done

--- a/packages/pacman/ChangeLog
+++ b/packages/pacman/ChangeLog
@@ -1,3 +1,8 @@
+6.0.1-2 (2021-09-10)
+
+	Remove gpg/key-signing support again for now. Too many external 
+	dependencies. Will look at other options.
+
 6.0.1-1 (2021-09-07)
 
 	Upgrade to 6.0.1

--- a/packages/pacman/PKGBUILD
+++ b/packages/pacman/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=(pacman pacman-build)
 pkgver=6.0.1
-pkgrel=1
+pkgrel=2
 pkgdesc='A lightweight Package Manager'
 arch=(x86_64)
 url='https://www.archlinux.org/pacman/'
@@ -11,12 +11,9 @@ license=(GPL2)
 groups=()
 depends=()
 makedepends=(
-    gpgme-dev
     libacl-dev
     libarchive-dev
-    libassuan-dev
     libcurl-dev
-    libgpg-error-dev
     liblzma-dev
     ninja
     openssl-dev
@@ -71,7 +68,6 @@ package_pacman() {
         usr/bin/pacman
         usr/bin/pacman-conf
         usr/bin/pacman-db-upgrade
-        usr/bin/pacman-key
         usr/bin/vercmp
         etc/pacman.conf*
         var
@@ -110,7 +106,6 @@ package_pacman-build() {
         curl
         fedup
         file
-        gnupg
         libarchive
         "pacman=${pkgver}"
         xz


### PR DESCRIPTION
For now, there are too many base system dependencies when using pacman's
gpg implementation. It requires gpg and friends to be installed on the
system as well as bash and bash libs for pacman-key. Digital signing
will be looked at through other mechanisms

See this comment: https://github.com/jhuntwork/merelinux/issues/7#issuecomment-916926986