### PR TITLE
[binutils] Re-add at 2.37

### DIFF
--- a/packages/binutils/ChangeLog
+++ b/packages/binutils/ChangeLog
@@ -1,0 +1,4 @@
+2.37-1 (2021-08-31)
+
+	Re-add binutils as secondary linker tools for use with gcc
+

--- a/packages/binutils/PKGBUILD
+++ b/packages/binutils/PKGBUILD
@@ -1,0 +1,52 @@
+#!/bin/bash
+# shellcheck disable=SC2034,SC2154
+
+pkgname='binutils'
+rationale='This is part of the core toolchain'
+pkgver=2.37
+pkgrel=1
+pkgdesc='A collection of binary tools, including a linker and an assembler'
+arch=(x86_64)
+url='http://www.gnu.org/software/binutils/'
+license=(GPL3)
+groups=()
+depends=()
+makedepends=(zlib-dev)
+options=()
+changelog=ChangeLog
+
+source=(
+    "http://ftp.gnu.org/gnu/binutils/binutils-${pkgver}.tar.xz"
+)
+
+sha256sums=(
+    820d9724f020a3e69cb337893a0b63c2db161dadcb0e06fc11dc29eb1e84a32c
+)
+
+build() {
+    cd_unpacked_src
+    mkdir build
+    cd build || return 1
+    ../configure --prefix=/opt/binutils \
+      --build="$CHOST" \
+      --host="$CHOST" \
+      --target="$CHOST" \
+      --enable-64-bit-bfd \
+      --disable-plugins \
+      --disable-shared \
+      --disable-werror \
+      --disable-nls \
+      --with-system-zlib \
+      --mandir=/opt/binutils/share/man
+    make tooldir=/opt/binutils
+}
+
+package() {
+    depends=(
+        "ld-musl-$(arch).so.1"
+    )
+    cd_unpacked_src
+    cd build || return 1
+    make DESTDIR="$pkgdir" tooldir=/opt/binutils install
+    rm -rf "${pkgdir:?}/opt/binutils/info"
+}


### PR DESCRIPTION
binutils is needed by gcc, which is needed to build syslinux

Related to #237