### PR TITLE
[syslinux] Re-package, building with gcc-9.4

### DIFF
--- a/packages/syslinux/ChangeLog
+++ b/packages/syslinux/ChangeLog
@@ -1,9 +1,13 @@
-2018-12-15  Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
+6.03-6 (2021-09-11)
 
-	* 6.03-5 :
+	Re-package, building with gcc-9.4 and removing some unused headers/libs
+	Remove from base group
+	Remove dependency on perl, for now, though some packaged tools` are perl
+
+6.03-5 (2018-12-15)
+
 	Add efi64 support
 
-2015-03-16 Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
+6.03-1 (2015-03-16)
 
-	* 6.03-1 :
 	Initial version

--- a/packages/syslinux/PKGBUILD
+++ b/packages/syslinux/PKGBUILD
@@ -1,17 +1,21 @@
 #!/bin/bash
 # shellcheck disable=SC2034,SC2154,SC2068
-# Maintainer: Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
 
 pkgname=syslinux
 pkgver=6.03
-pkgrel=5
+pkgrel=6
 pkgdesc='Lightweight Linux bootloaders.'
 arch=(x86_64)
 url=http://syslinux.org/
 license=(BSD)
-groups=(base)
-depends=(musl perl)
-makedepends=(perl libuuid-dev)
+groups=()
+depends=()
+makedepends=(
+    binutils
+    libuuid-dev
+    gcc
+    perl
+)
 options=()
 changelog=ChangeLog
 source=(
@@ -24,26 +28,27 @@ sha256sums=(
 
 
 build() {
-    cd "${srcdir}/${pkgname}-${pkgver}" || return 1
-    unset MAKEFLAGS
-    sed -i -e '/^BINDIR/s@=.*@= /bin@' \
-           -e '/^LIBDIR/s@=.*@= /lib@' \
-           -e '/^DATADIR/s@=.*@= /share@' \
-           -e '/^MANDIR/s@=.*@= /share/man@' \
-           -e '/^INCDIR/s@=.*@= /include@' mk/syslinux.mk com32/lib/Makefile
-    make LD='ld.bfd' efi64 bios installer
+    cd_unpacked_src
+    export PATH="/opt/binutils/bin:${PATH}"
+    sed -i -e 's@malign@falign@g' mk/*
+    sed -i "/types.h/s@.*@#include <sys/sysmacros.h>\n&@" extlinux/main.c
+    MAKEFLAGS='' make efi64 bios installer
 }
 
 package() {
     pkgfiles=(
-        bin
-        sbin
-        share
+        usr/sbin/
+        usr/bin
+        usr/share
     )
-    cd "${srcdir}/${pkgname}-${pkgver}" || return 1
-    unset MAKEFLAGS
-    make LD='ld.bfd' INSTALLROOT="${pkgdirbase}/dest" efi64 bios install
+    depends=(
+        "ld-musl-$(arch).so.1"
+    )
+    cd_unpacked_src
+    MAKEFLAGS='' make INSTALLROOT="${pkgdirbase}/dest" efi64 bios install
     cd "${pkgdirbase}/dest" || return 1
-    set -o pipefail
-    find ${pkgfiles[@]} | cpio -dump "${pkgdir}"
+    install -d usr/sbin
+    mv sbin/extlinux usr/sbin/
+    find . -not -type d \( -name "*.a" -o -name "*.h" \) -delete
+    package_defined_files
 }


### PR DESCRIPTION
Also:

- Remove some unused headers/libs
- Remove from base group
- Remove dependency on perl, while keeping some rarely used perl scripts
  shipped with the package

Fixes #237