### PR TITLE
[musl] Remove utmpx support

### DIFF
--- a/packages/musl/ChangeLog
+++ b/packages/musl/ChangeLog
@@ -1,3 +1,8 @@
+1.2.2-7 (2021-09-12)
+
+	Configure utmp.h to use utmps paths
+	Remove utmpx support as it will be provided by utmps
+
 1.2.2-6 (2021-09-05)
 
 	Move from core-dev group to build-base group

--- a/packages/musl/PKGBUILD
+++ b/packages/musl/PKGBUILD
@@ -1,10 +1,9 @@
 #!/bin/bash
 # shellcheck disable=SC2034,SC2154,SC2068
 
-rationale='This is part of the core toolchain'
 pkgname=(musl musl-dev)
 pkgver=1.2.2
-pkgrel=6
+pkgrel=7
 pkgdesc='An implementation of the C/POSIX standard library.'
 arch=(x86_64)
 url='https://musl.libc.org'
@@ -24,6 +23,14 @@ sha256sums=(
 build() {
     cd_unpacked_src
     unset CFLAGS CXXFLAGS
+    # Disable utmpx since utmps will provide it, avoid duplicate symbols in libs
+    # Also set default utmp paths to ones utmps will handle
+    sed -i \
+        -e 's@/dev/null/utmp@/run/utmps/utmp@' \
+        -e 's@/dev/null/wtmp@/var/log/wtmp@' \
+        -e "/utmpx.h/s@.*@#define __NEED_time_t\n#include <bits/alltypes.h>@" \
+        include/utmp.h
+    rm src/legacy/utmpx.c include/utmpx.h
     ./configure --prefix=/usr \
         --libdir=/lib \
         --syslibdir=/lib


### PR DESCRIPTION
The utmps package will provide utmpx, so remove the header and lib
symbols and adjust utmp paths to point at ones utmps will
provide/support.