### PR TITLE
[s6] Adjust mdevd configuration

### DIFF
--- a/packages/s6/ChangeLog
+++ b/packages/s6/ChangeLog
@@ -1,3 +1,9 @@
+2.10.0.3-7 (2021-09-12)
+
+	Move mdevd service configuration and files to mdevd package, similar 
+	pattern as utmps
+	Remove dependency on mdevd. Allows to run without modules if desired.
+
 2.10.0.3-6 (2021-09-05)
 
 	Move from core group to base group

--- a/packages/s6/PKGBUILD
+++ b/packages/s6/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=(s6 s6-dev)
 pkgver=2.10.0.3
-pkgrel=6
+pkgrel=7
 pkgdesc='A small process supervision suite for UNIX.'
 arch=(x86_64)
 url='http://skarnet.org/software/s6/'
@@ -15,7 +15,6 @@ options=(emptydirs)
 changelog=ChangeLog
 source=(
     "http://skarnet.org/software/s6/s6-${pkgver}.tar.gz"
-    mdevd-service
     rc.init
     rc.shutdown
     s6.install
@@ -32,8 +31,7 @@ source=(
 
 sha256sums=(
     1d21373151704150df0e8ed199f097f6ee5d2befb9a68aca4f20f3862e5d8757
-    9ca3f44a433f800d88a49be522c1ca6943b2035715b7368b42767cc49850c997
-    33ade9b012439977931e2b7999cddda26f9dc64dc0768b6d4b94cad01d63be37
+    719101b2a26b1e85dd40f5e69fad66ad866ce1ac79764ada4b3ef0b5c62cfc89
     db0e8c503e72eb05356a4ec9a65903a6d6447b5786453d0d8dbf097534c89ad5
     6ba76e90d72d7e59763a0ec42304d46abfd17548b1d52485dcf2e5306998887e
     ad6fc42721170dbceefaa55a3e3010d023420de5a1882735a1eab32ac9ec92d4
@@ -69,7 +67,7 @@ package_s6() {
         sbin
         lib/s6
     )
-    depends=(execline mdevd)
+    depends=(execline)
     groups=(base)
 
     # Run make install
@@ -95,10 +93,6 @@ package_s6() {
     install -d etc/s6/init-services/.s6-svscan
     install -m 0750 "${srcdir}/s6-svscan-crash" etc/s6/init-services/.s6-svscan/crash
     install -m 0750 "${srcdir}/s6-svscan-finish" etc/s6/init-services/.s6-svscan/finish
-
-    # mdevd service
-    install -d etc/s6/init-services/mdevd
-    install -m 0754 "${srcdir}/mdevd-service" etc/s6/init-services/mdevd/run
 
     # early tty1 and ttyS0 service
     install -d etc/s6/init-services/tty1 etc/s6/init-services/ttyS0

--- a/packages/s6/mdevd-service
+++ b/packages/s6/mdevd-service
@@ -1,2 +1,0 @@
-#!/bin/execlineb -P
-mdevd

--- a/packages/s6/rc.init
+++ b/packages/s6/rc.init
@@ -5,7 +5,12 @@ mount -o rw,remount /
 ln -s /proc/self/fd /dev/fd
 
 # Load modules
-mdevd-coldplug
+if command -v mdevd-coldplug >/dev/null 2>&1 && \
+        [ -d /etc/s6/init-services/mdevd ]; then
+    s6-svwait -U /s6/run/mdevd
+    install -d /run/.libudev-zero
+    mdevd-coldplug
+fi
 
 # Copy over enabled services and refresh
 find /etc/s6/services/enabled -maxdepth 1 -type l | while read -r dir ; do


### PR DESCRIPTION
Remove the mdevd service file and configuration. Those will be added to
the mdevd package in a future commit. This follows a similar pattern as
the utmps package and allows mdevd to be optionally installed, in case a
user wishes to run without kernel modules.

Also adjust the call to mdevd-coldplug to wait until mdevd has signaled
that it is up