### PR TITLE
[sudo] Add missing libs

### DIFF
--- a/packages/sudo/ChangeLog
+++ b/packages/sudo/ChangeLog
@@ -1,3 +1,7 @@
+1.9.7p2-5 (2021-09-12)
+
+	Add missing sudo libs
+
 1.9.7p2-4 (2021-09-12)
 
 	Build as dynamic again. Recent versions appear to require it.

--- a/packages/sudo/PKGBUILD
+++ b/packages/sudo/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=(sudo)
 pkgver=1.9.7p2
-pkgrel=4
+pkgrel=5
 pkgdesc='Tool for delegating authority to users and groups.'
 arch=(x86_64)
 url='http://www.sudo.ws/'
@@ -38,10 +38,11 @@ package() {
     options=(emptydirs)
     backup=(etc/sudoers etc/sudo.conf)
     pkgfiles=(
-        usr/bin
         etc/sudo.conf
         etc/sudoers
         etc/sudoers.d
+        usr/bin
+        usr/lib
         usr/sbin
         usr/share/man
     )


### PR DESCRIPTION
Switching from static binary to shared requires building and shipping
the internal dynamic libs as well