### PR TITLE
[musl] Leave the default utmp paths alone

### DIFF
--- a/packages/musl/ChangeLog
+++ b/packages/musl/ChangeLog
@@ -1,3 +1,7 @@
+1.2.2-8 (2021-09-15)
+
+	Leave the default utmp paths in musl alone
+
 1.2.2-7 (2021-09-12)
 
 	Configure utmp.h to use utmps paths

--- a/packages/musl/PKGBUILD
+++ b/packages/musl/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=(musl musl-dev)
 pkgver=1.2.2
-pkgrel=7
+pkgrel=8
 pkgdesc='An implementation of the C/POSIX standard library.'
 arch=(x86_64)
 url='https://musl.libc.org'
@@ -25,10 +25,7 @@ build() {
     unset CFLAGS CXXFLAGS
     # Disable utmpx since utmps will provide it, avoid duplicate symbols in libs
     # Also set default utmp paths to ones utmps will handle
-    sed -i \
-        -e 's@/dev/null/utmp@/run/utmps/utmp@' \
-        -e 's@/dev/null/wtmp@/var/log/wtmp@' \
-        -e "/utmpx.h/s@.*@#define __NEED_time_t\n#include <bits/alltypes.h>@" \
+    sed -i "/utmpx.h/s@.*@#define __NEED_time_t\n#include <bits/alltypes.h>@" \
         include/utmp.h
     rm src/legacy/utmpx.c include/utmpx.h
     ./configure --prefix=/usr \


### PR DESCRIPTION
Things that should be using utmp should be talking to utmps via its
client library and the running utmps service. Everything else that is
falling back to utmp.h and standard lib should really be going to
/dev/null (the default musl path) as insecure