### PR TITLE
Update Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-FROM scratch as build
+FROM mere/base as build
 
-ADD busybox-1.32.1-4-x86_64.pkg.tar.xz \
-    pacman-5.2.2-2-x86_64.pkg.tar.xz \
-    /
-
-RUN install -d /tmp/system/var/lib/pacman && \
-    pacman -r /tmp/system -Sy base-layout busybox pacman --noconfirm && \
-    rm -rf /tmp/system/var/cache/pacman/pkg/*
+RUN install -d /tmp/system/var/lib/pacman
+RUN pacman -r /tmp/system -Sy base-layout busybox pacman --noconfirm
+RUN rm /tmp/system/etc/services \
+       /tmp/system/etc/protocols \
+       /tmp/system/etc/pacman.conf.example \
+       /tmp/system/usr/bin/pacman-conf
 
 FROM scratch
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,17 +1,13 @@
 FROM mere/base
 
-RUN rm -f /usr/local && chmod 755 /usr
-
 COPY packages/pacman/pacman-dev.conf /etc/pacman.conf
 
 RUN install -d /mere/pkgs && \
     touch /mere/pkgs/buildlocal.db && \
     pacman -Syu --noconfirm && \
-    pacman -Sy --noconfirm base-layout busybox build-base pacman-build sudo && \
+    pacman -Sy --noconfirm build-base pacman-build sudo && \
     rm -rf /var/lib/pacman/sync && \
     printf 'merebuild ALL=(ALL) NOPASSWD: ALL\n' >>/etc/sudoers && \
     find /var/cache/pacman -not -type d -delete
-
-WORKDIR /src
 
 CMD ["/bin/sh"]


### PR DESCRIPTION
Improve the main Dockerfile to be contextless. Can build with tools from
previous mere/base images. Prefer multi stage builds there that allow us
to avoid chaining commands in one RUN statement.

Small tweaks to dev.Dockerfile, remove some older instructions that are
no longer needed