### PR TITLE
Fix path in ci scripts of pacman binary

### DIFF
--- a/ci-scripts/ci-upload.sh
+++ b/ci-scripts/ci-upload.sh
@@ -17,7 +17,7 @@ case "$bn" in
         tar -C /tmp/pacman -xf pacman-latest-x86_64.pkg.tar.xz 2>/dev/null
 
         install -d ./var/lib/pacman
-        sudo /tmp/pacman/bin/pacman -Sy --config /tmp/pacman/etc/pacman.conf \
+        sudo /tmp/pacman/usr/bin/pacman -Sy --config /tmp/pacman/etc/pacman.conf \
             -r . --noconfirm pacman-build
         sudo sed -i '/bsdtar -xf .*dbfile/s@-C@--no-fflags -C@' bin/repo-add
 


### PR DESCRIPTION
More recent versions are using /usr/bin instead of /bin