### PR TITLE
[skalibs] Adjust paths

### DIFF
--- a/packages/skalibs/ChangeLog
+++ b/packages/skalibs/ChangeLog
@@ -1,3 +1,7 @@
+2.10.0.3-3 (2021-09-21)
+
+	Fix skalibs paths to be consistent with system includes
+
 2.10.0.3-2 (2021-09-12)
 
 	List provides on skalibs for libskarnet

--- a/packages/skalibs/PKGBUILD
+++ b/packages/skalibs/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=(
     skalibs-dev
 )
 pkgver=2.10.0.3
-pkgrel=2
+pkgrel=3
 pkgdesc='A library suite supporting skarnet.org software.'
 arch=(x86_64)
 url=http://skarnet.org/software/skalibs/
@@ -29,7 +29,10 @@ sha256sums=(
 build() {
     cd_unpacked_src
     ./configure \
-      --prefix=/ \
+      --prefix=/usr \
+      --dynlibdir=/lib \
+      --libdir=/lib \
+      --sysdepdir=/lib/skalibs/sysdeps \
       --disable-ipv6 \
       --enable-force-devr \
       --enable-tai-clock
@@ -46,16 +49,12 @@ package_skalibs() {
     provides=(
         libskarnet.so.2.10
     )
-    cd_unpacked_src
-    make DESTDIR="${pkgdirbase}/dest" install
-    cd "${pkgdirbase}/dest" || return 1
-    mv lib/skalibs/libskarnet.a lib
-    package_defined_files
+    std_package
 }
 
 package_skalibs-dev() {
     pkgfiles=(
-        include/skalibs
+        usr/include/skalibs
         lib/skalibs/sysdeps
         lib/libskarnet.a
         lib/libskarnet.so


### PR DESCRIPTION
Effectively just moves the headers to /usr/include instead of the
odd /include directory