### PR TITLE
[libmilter] Fix a bug in the pthread stack size

### DIFF
--- a/packages/libmilter/ChangeLog
+++ b/packages/libmilter/ChangeLog
@@ -1,3 +1,7 @@
+8.17.1-2 (2021-09-30)
+
+	Fix a bug in the pthread stack size
+
 8.17.1-1 (2021-09-30)
 
 	Initial version

--- a/packages/libmilter/PKGBUILD
+++ b/packages/libmilter/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=(libmilter-dev)
 pkgver=8.17.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Sendmail's milter library"
 arch=(x86_64)
 url='http://sendmail.org'
@@ -16,17 +16,26 @@ changelog=ChangeLog
 
 source=(
     "ftp://ftp.sendmail.org/pub/sendmail/sendmail.${pkgver}.tar.gz"
+    "https://git.alpinelinux.org/aports/plain/main/libmilter/default-pthread-stacksize.patch"
 )
 
 sha256sums=(
     04bc76b6c886e6d111be7fd8daa32b8ce00128a288b6b52e067bc29f3854a6e6
+    d04f6f653c64857843f84a76991cdc3cbbff84093e43cc0baf5485b2f726056c
 )
 
 
 build() {
     cd_unpacked_src
+    patch -Np1 -i "${srcdir}/default-pthread-stacksize.patch"
     sed -i '/SM_CONF_SYS_CDEFS_H/s@1@0@' include/sm/os/sm_os_linux.h
-    make -C libmilter
+    cat >> devtools/Site/site.config.m4 <<-EOF
+		dnl getipnodebyname/getipnodebyaddr is deprecated and not part of musl libc
+		APPENDDEF(\`conf_libmilter_ENVDEF',\`-DNEEDSGETIPNODE=1')
+        APPENDDEF(\`confENVDEF',\`$CFLAGS')
+	EOF
+    cd libmilter || return 1
+    MAKEFLAGS='' ./Build
 }
 
 package() {


### PR DESCRIPTION
More information found in the alpine patch:
https://git.alpinelinux.org/aports/tree/main/libmilter/default-pthread-stacksize.patch