### PR TITLE
Adjust CI to support some parallel builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,15 @@
 version: 2.1
 executors:
-  lint-env:
+  dev-image:
     docker:
       - image: mere/dev
-  build-env:
+  build-machine:
+    resource_class: large
     machine:
-      image: ubuntu-2004:202107-02
+      image: ubuntu-2204:2022.10.2
 jobs:
   lint:
-    executor: lint-env
+    executor: dev-image
     steps:
       - run:
           name: Install tools and upgrade
@@ -20,8 +21,29 @@ jobs:
             find packages -name PKGBUILD -exec shellcheck '{}' +
             find packages -name PKGTEST -exec shellcheck '{}' +
             find buildpkg.sh ci-scripts dev-scripts misc-util -type f -exec shellcheck '{}' +
+  build-parallel:
+    executor: build-machine
+    steps:
+      - checkout
+      - run:
+          name: Setup Build
+          command: ./ci-scripts/ci-setup.sh
+      - run:
+          name: Build package
+          command: ./ci-scripts/ci-build.sh
+          no_output_timeout: 20m
+      - run:
+          name: Test package
+          command: ./ci-scripts/ci-test.sh
+      - run:
+          name: Cleanup
+          command: sudo tailscale logout
+          when: always
+      - store_artifacts:
+          path: /tmp/mere
+    parallelism: 6
   build:
-    executor: build-env
+    executor: build-machine
     steps:
       - checkout
       - run:
@@ -37,7 +59,7 @@ jobs:
       - store_artifacts:
           path: /tmp/mere
   upload:
-    executor: build-env
+    executor: build-machine
     steps:
       - add_ssh_keys
       - checkout
@@ -52,20 +74,28 @@ jobs:
 
 workflows:
   version: 2
-  workflow:
+  parallel:
+    when:
+      matches:
+        pattern: "^.*-parallel$"
+        value: << pipeline.git.branch >>
     jobs:
-      - lint:
-          filters:
-            branches:
-              ignore: main
-      - build:
-          filters:
-            branches:
-              ignore: main
-          requires:
-            - lint
-      - upload:
-          filters:
-            branches:
-              only:
-                - main
+      - lint
+      - build-parallel
+  single:
+    when:
+      and:
+        - not:
+            matches:
+              pattern: "^.*-parallel$"
+              value: << pipeline.git.branch >>
+        - not:
+            equal: [ main, << pipeline.git.branch >> ]
+    jobs:
+      - lint
+      - build
+  upload:
+    when:
+      equal: [ main, << pipeline.git.branch >> ]
+    jobs:
+      - upload

--- a/buildpkg.sh
+++ b/buildpkg.sh
@@ -79,8 +79,10 @@ case "$cmd" in
             -v "$tmpdir":"$tmpdir" \
             -v "$MEREDIR":/mere \
             -v "$(pwd)"/mere.key:/tmp/mere.key \
-            -v "$(pwd)"/dev-scripts:/usr/local/bin \
+            -v "$(pwd)"/dev-scripts/build-in-docker:/usr/local/bin/build-in-docker \
+            -v "$(pwd)"/dev-scripts/aa-distcc.sh:/usr/share/makepkg/tidy/aa-distcc.sh \
             -v "$(pwd)"/packages/pacman/pacman-dev.conf:/etc/pacman.conf \
+            --env-file ./.env \
             mere/dev:latest "$cmd"
         printf '\nNew package(s) added to %s\n' "${MEREDIR}/pkgs"
         printf 'Build logs are located at %s\n' "${MEREDIR}/logs"

--- a/ci-scripts/ci-build.sh
+++ b/ci-scripts/ci-build.sh
@@ -4,7 +4,50 @@ bn="$(git rev-parse --abbrev-ref HEAD)"
 if [ "$bn" != 'main' ] ; then
     . "$CIRCLE_WORKING_DIRECTORY"/.env
     if [ -n "$pkg" ] && [ "$is_deleted" = 'false' ]; then
-        sudo MEREDIR="/tmp/mere" -E ./buildpkg.sh "$pkg"
+
+        if printf '%s' "$bn" | grep -qE '^.*-parallel$'; then
+
+            DISTCC_PORT='40000'
+            DISTCC_CIDR='172.0.0.0/8'
+
+            curl -fsSL https://tailscale.com/install.sh | sudo sh
+            sudo tailscale up --authkey="$TS_KEY" \
+                --hostname="mereci-${CIRCLE_BUILD_NUM}-${CIRCLE_NODE_TOTAL}-${CIRCLE_NODE_INDEX}"
+
+            case "$CIRCLE_NODE_INDEX" in
+                0)
+                    DISTCC_HOSTS='localhost'
+                    step=1
+                    while [ "$step" -lt "$CIRCLE_NODE_TOTAL" ]; do
+                        peerip=$(dig +short "mereci-${CIRCLE_BUILD_NUM}-${CIRCLE_NODE_TOTAL}-${step}.bonobo-bluegill.ts.net")
+                        until [ -n "$peerip" ]; do
+                            sleep 5
+                            peerip=$(dig +short "mereci-${CIRCLE_BUILD_NUM}-${CIRCLE_NODE_TOTAL}-${step}.bonobo-bluegill.ts.net")
+                        done
+                        DISTCC_HOSTS="${DISTCC_HOSTS} ${peerip}:${DISTCC_PORT}"
+                        step=$((step + 1))
+                    done
+                    cat >.env <<-EOF
+					DISTCC_HOSTS=$DISTCC_HOSTS
+					CC=/usr/lib/distcc/cc
+					CXX=/usr/lib/distcc/c++
+					EOF
+                    MEREDIR="/tmp/mere" ./buildpkg.sh "$pkg"
+                    ;;
+                *)
+                    printf 'Listening on port %s\n' "$DISTCC_PORT"
+                    docker run -t --rm \
+                        -p "$DISTCC_PORT":"$DISTCC_PORT" -e DISTCC_PORT="$DISTCC_PORT" \
+                        -e DISTCC_CIDR="$DISTCC_CIDR" mere/distcc &
+                    # Listen on this port for any input to "signal" build job is finished
+                    printf 'Listening for done signal on port 40001\n'
+                    nc -l -p 40001
+                    ;;
+
+            esac
+        else
+            MEREDIR="/tmp/mere" ./buildpkg.sh "$pkg"
+        fi
     else
         printf 'No packages are required to build in this commit.\n'
     fi

--- a/dev-scripts/aa-distcc.sh
+++ b/dev-scripts/aa-distcc.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+[ -n "$LIBMAKEPKG_TIDY_DISTCC_SH" ] && return
+LIBMAKEPKG_TIDY_DISTCC_SH=1
+
+LIBRARY=${LIBRARY:-'/usr/share/makepkg'}
+
+# shellcheck disable=SC1091
+source "$LIBRARY/util/message.sh"
+# shellcheck disable=SC1091
+source "$LIBRARY/util/option.sh"
+
+packaging_options+=('distcc')
+tidy_remove+=('tidy_distcc')
+
+tidy_distcc() {
+    if [ -n "$DISTCC_HOSTS" ] && [ ! -f /tmp/signalled-distcc ]; then
+        for host in $DISTCC_HOSTS; do
+            [ "$host" = 'localhost' ] && continue
+            msg2 "$(gettext "Sending done signal to ${host%:*}...")"
+            echo 'done' | nc "${host%:*}" 40001
+        done
+        touch /tmp/signalled-distcc
+    fi
+}


### PR DESCRIPTION
When using a branch name ending in -parallel, launch multiple build
machines that can use distcc together for increased build times.