### PR TITLE
Update hwdata and inih recipes

### DIFF
--- a/recipes/core/inih/recipe.kdl
+++ b/recipes/core/inih/recipe.kdl
@@ -1,6 +1,6 @@
 recipe {
     name "inih"
-    version "59"
+    version "62"
     release 1
     description "Simple INI file parser library"
     url "https://github.com/benhoyt/inih"
@@ -11,7 +11,7 @@ recipe {
 }
 
 source "https://github.com/benhoyt/inih/archive/refs/tags/r${recipe.version}.tar.gz" {
-    blake3 "92193920728e471f7c5275be6daa2f5bfd092e84ed47d2c0614564ec2510fd45"
+    blake3 "d3e654d280e40c816cf4497f2899ba707e610717e34acd06f9d5224cfdbb6c3f"
 }
 
 build {
@@ -33,7 +33,7 @@ includedir=${prefix}/include
 
 Name: inih
 Description: Simple INI file parser
-Version: 59
+Version: 62
 Libs: -L${libdir} -linih
 Cflags: -I${includedir}
 EOF

--- a/recipes/desktop/hwdata/recipe.kdl
+++ b/recipes/desktop/hwdata/recipe.kdl
@@ -1,16 +1,16 @@
 recipe {
     name "hwdata"
-    version "0.406"
+    version "0.410"
     release 1
     description "Hardware identification and configuration data (pci.ids, usb.ids)"
     url "https://github.com/vcrhonek/hwdata"
-    archs "aarch64" "x86_64"
+    archs "any"
     licenses "GPL2"
     depends "busybox" "make"
 }
 
 source "https://github.com/vcrhonek/hwdata/archive/refs/tags/v${recipe.version}.tar.gz" {
-    blake3 "c9ac9ad3b6b3bc38ba1a163b53b7378d605c4a02e405537ac4eafe516a27c2b8"
+    blake3 "546817858aabc287c742bd064e9c5cdafdc76e4a9ac91412c4460ca50c16c552"
 }
 
 build {


### PR DESCRIPTION
Update two small recipes to current upstream releases to exercise the GitHub Actions build path.

- hwdata 0.406 → 0.410 and mark it architecture-independent.
- inih r59 → r62, including pkg-config metadata.