### PR TITLE
Fit recipe builds to hosted runners

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -100,7 +100,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     container:
       image: mere/ci:v0.18.1
-      options: --privileged --cpus=8 --memory=12g
+      options: --privileged --cpus=4 --memory=12g
     strategy:
       matrix: ${{ fromJSON(needs.detect.outputs.matrix) }}
       fail-fast: false


### PR DESCRIPTION
The hosted x86_64 and ARM64 runners expose four CPUs, so the previous --cpus=8 container option caused every trusted recipe build to fail during container initialization.

Use --cpus=4, matching both runner types. This is a workflow-only correction; recipe and secret handling are unchanged.