### PR TITLE
Disable cache reads for recipe builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -154,7 +154,7 @@ jobs:
         run: |
           set -eu
           cd "$GITHUB_WORKSPACE"
-          mere dev build "${{ matrix.recipe }}"
+          mere dev build --no-cache "${{ matrix.recipe }}"
 
       - name: Publish to pkgd
         run: |


### PR DESCRIPTION
Disable build-cache reads in the trusted recipe workflow while retaining fresh cache writes.

GitHub-hosted container jobs are currently failing during Mere package-archive cache restoration with a filesystem error after source fetch, dependency installation, and build/install cache restoration succeed. This lets us test fresh namespace builds and packaging independently of that restore path.

The existing --no-cache flag is Mere-supported and does not weaken source checksum verification, package signing, or publication.