### PR TITLE
Use Mere 0.18.5 CI images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
   detect:
     runs-on: ubuntu-24.04-arm
     container:
-      image: mere/ci:v0.18.4
+      image: mere/ci:v0.18.5
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       MANUAL_RECIPES: ${{ inputs.recipes }}
@@ -120,7 +120,7 @@ jobs:
     if: needs.detect.outputs.has_recipes == 'true'
     runs-on: ${{ matrix.runner }}
     container:
-      image: mere/ci:v0.18.4
+      image: mere/ci:v0.18.5
       options: --privileged --cpus=4 --memory=12g
     strategy:
       matrix: ${{ fromJSON(needs.detect.outputs.matrix) }}

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -10,7 +10,7 @@ jobs:
   validate:
     runs-on: ubuntu-24.04
     container:
-      image: mere/ci:v0.18.4
+      image: mere/ci:v0.18.5
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
Update GitHub Actions container jobs to use the released Mere v0.18.5 image.