### PR TITLE
Use HOME for signing key path

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -145,10 +145,10 @@ jobs:
         run: |
           set -eu
           grep -q '^root:' /etc/passwd 2>/dev/null || printf 'root:x:0:0:root:/root:/bin/sh\n' >> /etc/passwd
-          install -d -m 700 /root
-          install -d -m 700 /root/.mere/keys
-          printf '%s' "$MERE_SIGNING_KEY" | base64 -d > /root/.mere/keys/mere.key
-          chmod 600 /root/.mere/keys/mere.key
+          key_dir="${HOME:?}/.mere/keys"
+          install -d -m 700 "$key_dir"
+          printf '%s' "$MERE_SIGNING_KEY" | base64 -d > "$key_dir/mere.key"
+          chmod 600 "$key_dir/mere.key"
 
       - name: Build
         run: |


### PR DESCRIPTION
Install the trusted build signing key under the container HOME so Mere resolves it at the path used by GitHub container jobs.