### PR TITLE
Build linux-headers per architecture

### DIFF
--- a/recipes/core/linux-headers/recipe.kdl
+++ b/recipes/core/linux-headers/recipe.kdl
@@ -1,10 +1,11 @@
 recipe {
     name "linux-headers"
     version "6.19.5"
-    release 1
+    release 2
     description "Linux kernel headers"
     url "http://www.kernel.org"
     licenses "GPL3"
+    archs "aarch64" "x86_64"
     depends "busybox" "llvm" "make" "mimalloc-dev" "musl-dev" "patch" "rsync"
 }
 


### PR DESCRIPTION
## Summary
- declare linux-headers as an aarch64 and x86_64 recipe
- bump release 1 to release 2 for the corrected package identity

This prevents architecture-specific kernel UAPI headers from being published as an `any` package.